### PR TITLE
docs: unignore all 5 documentation tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rescrv/policyai"
 [dependencies]
 arrrg = "0.6.0"
 arrrg_derive = "0.6.0"
-claudius = "0.12.0"
+claudius = "0.13.0"
 getopts = "0.2.21"
 guacamole = "0.10.0"
 rand = "0.9.0"

--- a/src/field.rs
+++ b/src/field.rs
@@ -10,7 +10,7 @@ use crate::{t64, OnConflict};
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use policyai::{Field, OnConflict};
 ///
 /// let field = Field::Bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
 //! use policyai::{PolicyType, Field, OnConflict, Manager};
 //!
 //! let policy_type = PolicyType {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -14,18 +14,37 @@ use crate::{ApplyError, Policy, Report, ReportBuilder, Usage};
 ///
 /// # Example
 ///
-/// ```ignore
-/// use policyai::{Manager, Policy};
+/// ```no_run
+/// use policyai::Manager;
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # use claudius::{Anthropic, MessageCreateParams, KnownModel, Model, MessageParam, MessageRole};
+/// # use policyai::{PolicyType, Policy, Usage};
 ///
 /// let mut manager = Manager::default();
-/// manager.add(policy1);
-/// manager.add(policy2);
+/// # let client = Anthropic::new(None)?;
+/// # let policy_type = PolicyType::parse("type TestPolicy { active: bool = true }")?;
+/// # let policy = Policy {
+/// #     r#type: policy_type,
+/// #     prompt: "Test policy".to_string(),
+/// #     action: serde_json::json!({}),
+/// # };
+/// manager.add(policy);
 ///
+/// # let template = MessageCreateParams {
+/// #     max_tokens: 1024,
+/// #     model: Model::Known(KnownModel::ClaudeSonnet40),
+/// #     messages: vec![],
+/// #     ..Default::default()
+/// # };
+/// # let mut usage = Some(Usage::default());
 /// let report = manager.apply(
 ///     &client,
 ///     template,
-///     "unstructured text data"
+///     "unstructured text data",
+///     &mut usage
 /// ).await?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Default)]
 pub struct Manager {

--- a/src/on_conflict.rs
+++ b/src/on_conflict.rs
@@ -11,7 +11,7 @@
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use policyai::{Field, OnConflict};
 ///
 /// let field = Field::StringEnum {

--- a/src/policy_type.rs
+++ b/src/policy_type.rs
@@ -21,7 +21,8 @@ impl PolicyType {
     /// Parse a PolicyType from its textual representation.
     ///
     /// # Example
-    /// ```ignore
+    /// ```
+    /// use policyai::PolicyType;
     /// let policy_type = PolicyType::parse("type MyPolicy { unread: bool = true }").unwrap();
     /// ```
     pub fn parse(input: &str) -> Result<Self, ParseError> {


### PR DESCRIPTION
Remove `ignore` annotations from doctests in:
- src/policy_type.rs: add proper import for PolicyType::parse example
- src/manager.rs: create comprehensive no_run example with async function
- src/on_conflict.rs: simple removal of ignore annotation
- src/field.rs: simple removal of ignore annotation
- src/lib.rs: simple removal of ignore annotation

Also update claudius dependency from 0.12.0 to 0.13.0.

All documentation tests now compile and run successfully, reducing
ignored test count from 5 to 0.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
