### PR TITLE
feat: add policyai-regression-report binary with comprehensive analysis

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,0 +1,410 @@
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct ConfusionMatrix {
+    pub true_positive: usize,
+    pub false_positive: usize,
+    pub true_negative: usize,
+    pub false_negative: usize,
+}
+
+impl ConfusionMatrix {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_prediction(&mut self, actual: bool, predicted: bool) {
+        match (actual, predicted) {
+            (true, true) => self.true_positive += 1,
+            (true, false) => self.false_negative += 1,
+            (false, true) => self.false_positive += 1,
+            (false, false) => self.true_negative += 1,
+        }
+    }
+
+    pub fn precision(&self) -> f64 {
+        let tp = self.true_positive as f64;
+        let fp = self.false_positive as f64;
+        if tp + fp == 0.0 {
+            0.0
+        } else {
+            tp / (tp + fp)
+        }
+    }
+
+    pub fn recall(&self) -> f64 {
+        let tp = self.true_positive as f64;
+        let fn_count = self.false_negative as f64;
+        if tp + fn_count == 0.0 {
+            0.0
+        } else {
+            tp / (tp + fn_count)
+        }
+    }
+
+    pub fn f1_score(&self) -> f64 {
+        let p = self.precision();
+        let r = self.recall();
+        if p + r == 0.0 {
+            0.0
+        } else {
+            2.0 * p * r / (p + r)
+        }
+    }
+
+    pub fn accuracy(&self) -> f64 {
+        let total =
+            (self.true_positive + self.false_positive + self.true_negative + self.false_negative)
+                as f64;
+        if total == 0.0 {
+            0.0
+        } else {
+            (self.true_positive + self.true_negative) as f64 / total
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct RegressionAnalysis {
+    pub total_reports: usize,
+    pub policyai_total_fields_matched: usize,
+    pub baseline_total_fields_matched: usize,
+    pub policyai_total_wrong_values: usize,
+    pub baseline_total_wrong_values: usize,
+    pub policyai_total_missing_fields: usize,
+    pub baseline_total_missing_fields: usize,
+    pub policyai_total_extra_fields: usize,
+    pub baseline_total_extra_fields: usize,
+    pub policyai_errors: usize,
+    pub baseline_errors: usize,
+    pub policyai_total_duration_ms: u64,
+    pub baseline_total_duration_ms: u64,
+}
+
+impl RegressionAnalysis {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_report(&mut self, metrics: &crate::data::Metrics) {
+        self.total_reports += 1;
+        self.policyai_total_fields_matched += metrics.policyai_fields_matched;
+        self.baseline_total_fields_matched += metrics.baseline_fields_matched;
+        self.policyai_total_wrong_values += metrics.policyai_fields_with_wrong_value;
+        self.baseline_total_wrong_values += metrics.baseline_fields_with_wrong_value;
+        self.policyai_total_missing_fields += metrics.policyai_fields_missing;
+        self.baseline_total_missing_fields += metrics.baseline_fields_missing;
+        self.policyai_total_extra_fields += metrics.policyai_extra_fields;
+        self.baseline_total_extra_fields += metrics.baseline_extra_fields;
+
+        if metrics.policyai_error.is_some() {
+            self.policyai_errors += 1;
+        }
+        if metrics.baseline_error.is_some() {
+            self.baseline_errors += 1;
+        }
+
+        self.policyai_total_duration_ms += metrics.policyai_apply_duration_ms as u64;
+        self.baseline_total_duration_ms += metrics.baseline_apply_duration_ms as u64;
+    }
+
+    pub fn policyai_avg_duration_ms(&self) -> f64 {
+        if self.total_reports == 0 {
+            0.0
+        } else {
+            self.policyai_total_duration_ms as f64 / self.total_reports as f64
+        }
+    }
+
+    pub fn baseline_avg_duration_ms(&self) -> f64 {
+        if self.total_reports == 0 {
+            0.0
+        } else {
+            self.baseline_total_duration_ms as f64 / self.total_reports as f64
+        }
+    }
+
+    pub fn policyai_error_rate(&self) -> f64 {
+        if self.total_reports == 0 {
+            0.0
+        } else {
+            self.policyai_errors as f64 / self.total_reports as f64
+        }
+    }
+
+    pub fn baseline_error_rate(&self) -> f64 {
+        if self.total_reports == 0 {
+            0.0
+        } else {
+            self.baseline_errors as f64 / self.total_reports as f64
+        }
+    }
+
+    pub fn policyai_avg_fields_matched(&self) -> f64 {
+        if self.total_reports == 0 {
+            0.0
+        } else {
+            self.policyai_total_fields_matched as f64 / self.total_reports as f64
+        }
+    }
+
+    pub fn baseline_avg_fields_matched(&self) -> f64 {
+        if self.total_reports == 0 {
+            0.0
+        } else {
+            self.baseline_total_fields_matched as f64 / self.total_reports as f64
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct FieldMatchAccuracyMatrix {
+    pub confusion_matrix: ConfusionMatrix,
+}
+
+impl FieldMatchAccuracyMatrix {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_report(&mut self, metrics: &crate::data::Metrics, expected_field_count: usize) {
+        // Actual = baseline correctly matches expected field count
+        let baseline_correct = metrics.baseline_fields_matched == expected_field_count;
+        // Predicted = PolicyAI correctly matches expected field count
+        let policyai_correct = metrics.policyai_fields_matched == expected_field_count;
+
+        self.confusion_matrix
+            .add_prediction(baseline_correct, policyai_correct);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::Metrics;
+
+    #[test]
+    fn confusion_matrix_new() {
+        let matrix = ConfusionMatrix::new();
+        assert_eq!(matrix.true_positive, 0);
+        assert_eq!(matrix.false_positive, 0);
+        assert_eq!(matrix.true_negative, 0);
+        assert_eq!(matrix.false_negative, 0);
+    }
+
+    #[test]
+    fn confusion_matrix_add_predictions() {
+        let mut matrix = ConfusionMatrix::new();
+
+        matrix.add_prediction(true, true);
+        assert_eq!(matrix.true_positive, 1);
+
+        matrix.add_prediction(true, false);
+        assert_eq!(matrix.false_negative, 1);
+
+        matrix.add_prediction(false, true);
+        assert_eq!(matrix.false_positive, 1);
+
+        matrix.add_prediction(false, false);
+        assert_eq!(matrix.true_negative, 1);
+
+        assert_eq!(matrix.true_positive, 1);
+        assert_eq!(matrix.false_negative, 1);
+        assert_eq!(matrix.false_positive, 1);
+        assert_eq!(matrix.true_negative, 1);
+    }
+
+    #[test]
+    fn confusion_matrix_precision() {
+        let mut matrix = ConfusionMatrix::new();
+        matrix.true_positive = 3;
+        matrix.false_positive = 2;
+
+        assert_eq!(matrix.precision(), 0.6);
+
+        let empty_matrix = ConfusionMatrix::new();
+        assert_eq!(empty_matrix.precision(), 0.0);
+    }
+
+    #[test]
+    fn confusion_matrix_recall() {
+        let mut matrix = ConfusionMatrix::new();
+        matrix.true_positive = 3;
+        matrix.false_negative = 1;
+
+        assert_eq!(matrix.recall(), 0.75);
+
+        let empty_matrix = ConfusionMatrix::new();
+        assert_eq!(empty_matrix.recall(), 0.0);
+    }
+
+    #[test]
+    fn confusion_matrix_f1_score() {
+        let mut matrix = ConfusionMatrix::new();
+        matrix.true_positive = 3;
+        matrix.false_positive = 2;
+        matrix.false_negative = 1;
+
+        let precision = 3.0 / 5.0;
+        let recall = 3.0 / 4.0;
+        let expected_f1 = 2.0 * precision * recall / (precision + recall);
+
+        assert!((matrix.f1_score() - expected_f1).abs() < 1e-10);
+
+        let empty_matrix = ConfusionMatrix::new();
+        assert_eq!(empty_matrix.f1_score(), 0.0);
+    }
+
+    #[test]
+    fn confusion_matrix_accuracy() {
+        let mut matrix = ConfusionMatrix::new();
+        matrix.true_positive = 3;
+        matrix.false_positive = 2;
+        matrix.true_negative = 4;
+        matrix.false_negative = 1;
+
+        assert_eq!(matrix.accuracy(), 0.7);
+
+        let empty_matrix = ConfusionMatrix::new();
+        assert_eq!(empty_matrix.accuracy(), 0.0);
+    }
+
+    #[test]
+    fn regression_analysis_new() {
+        let analysis = RegressionAnalysis::new();
+        assert_eq!(analysis.total_reports, 0);
+        assert_eq!(analysis.policyai_total_fields_matched, 0);
+        assert_eq!(analysis.baseline_total_fields_matched, 0);
+        assert_eq!(analysis.policyai_errors, 0);
+        assert_eq!(analysis.baseline_errors, 0);
+    }
+
+    #[test]
+    fn regression_analysis_add_report() {
+        let mut analysis = RegressionAnalysis::new();
+
+        let metrics = Metrics {
+            policyai_fields_matched: 5,
+            baseline_fields_matched: 3,
+            policyai_fields_with_wrong_value: 1,
+            baseline_fields_with_wrong_value: 2,
+            policyai_fields_missing: 0,
+            baseline_fields_missing: 1,
+            policyai_extra_fields: 2,
+            baseline_extra_fields: 0,
+            policyai_error: None,
+            baseline_error: Some("error".to_string()),
+            policyai_apply_duration_ms: 100,
+            baseline_apply_duration_ms: 150,
+            policyai_usage: None,
+            baseline_usage: None,
+        };
+
+        analysis.add_report(&metrics);
+
+        assert_eq!(analysis.total_reports, 1);
+        assert_eq!(analysis.policyai_total_fields_matched, 5);
+        assert_eq!(analysis.baseline_total_fields_matched, 3);
+        assert_eq!(analysis.policyai_total_wrong_values, 1);
+        assert_eq!(analysis.baseline_total_wrong_values, 2);
+        assert_eq!(analysis.policyai_total_missing_fields, 0);
+        assert_eq!(analysis.baseline_total_missing_fields, 1);
+        assert_eq!(analysis.policyai_total_extra_fields, 2);
+        assert_eq!(analysis.baseline_total_extra_fields, 0);
+        assert_eq!(analysis.policyai_errors, 0);
+        assert_eq!(analysis.baseline_errors, 1);
+        assert_eq!(analysis.policyai_total_duration_ms, 100);
+        assert_eq!(analysis.baseline_total_duration_ms, 150);
+    }
+
+    #[test]
+    fn regression_analysis_averages() {
+        let mut analysis = RegressionAnalysis::new();
+
+        // Add two reports
+        let metrics1 = Metrics {
+            policyai_fields_matched: 4,
+            baseline_fields_matched: 2,
+            policyai_fields_with_wrong_value: 0,
+            baseline_fields_with_wrong_value: 1,
+            policyai_fields_missing: 1,
+            baseline_fields_missing: 2,
+            policyai_extra_fields: 0,
+            baseline_extra_fields: 0,
+            policyai_error: Some("error".to_string()),
+            baseline_error: None,
+            policyai_apply_duration_ms: 200,
+            baseline_apply_duration_ms: 300,
+            policyai_usage: None,
+            baseline_usage: None,
+        };
+
+        let metrics2 = Metrics {
+            policyai_fields_matched: 6,
+            baseline_fields_matched: 4,
+            policyai_fields_with_wrong_value: 2,
+            baseline_fields_with_wrong_value: 1,
+            policyai_fields_missing: 0,
+            baseline_fields_missing: 1,
+            policyai_extra_fields: 1,
+            baseline_extra_fields: 2,
+            policyai_error: None,
+            baseline_error: Some("error".to_string()),
+            policyai_apply_duration_ms: 100,
+            baseline_apply_duration_ms: 200,
+            policyai_usage: None,
+            baseline_usage: None,
+        };
+
+        analysis.add_report(&metrics1);
+        analysis.add_report(&metrics2);
+
+        assert_eq!(analysis.total_reports, 2);
+        assert_eq!(analysis.policyai_avg_fields_matched(), 5.0); // (4 + 6) / 2
+        assert_eq!(analysis.baseline_avg_fields_matched(), 3.0); // (2 + 4) / 2
+        assert_eq!(analysis.policyai_avg_duration_ms(), 150.0); // (200 + 100) / 2
+        assert_eq!(analysis.baseline_avg_duration_ms(), 250.0); // (300 + 200) / 2
+        assert_eq!(analysis.policyai_error_rate(), 0.5); // 1 error out of 2 reports
+        assert_eq!(analysis.baseline_error_rate(), 0.5); // 1 error out of 2 reports
+    }
+
+    #[test]
+    fn confusion_matrix_serialization() {
+        let mut matrix = ConfusionMatrix::new();
+        matrix.true_positive = 1;
+        matrix.false_positive = 2;
+        matrix.true_negative = 3;
+        matrix.false_negative = 4;
+
+        let serialized = serde_json::to_string(&matrix).unwrap();
+        let deserialized: ConfusionMatrix = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(matrix.true_positive, deserialized.true_positive);
+        assert_eq!(matrix.false_positive, deserialized.false_positive);
+        assert_eq!(matrix.true_negative, deserialized.true_negative);
+        assert_eq!(matrix.false_negative, deserialized.false_negative);
+    }
+
+    #[test]
+    fn regression_analysis_serialization() {
+        let mut analysis = RegressionAnalysis::new();
+        analysis.total_reports = 10;
+        analysis.policyai_total_fields_matched = 50;
+        analysis.baseline_total_fields_matched = 40;
+        analysis.policyai_errors = 2;
+        analysis.baseline_errors = 3;
+
+        let serialized = serde_json::to_string(&analysis).unwrap();
+        let deserialized: RegressionAnalysis = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(analysis.total_reports, deserialized.total_reports);
+        assert_eq!(
+            analysis.policyai_total_fields_matched,
+            deserialized.policyai_total_fields_matched
+        );
+        assert_eq!(
+            analysis.baseline_total_fields_matched,
+            deserialized.baseline_total_fields_matched
+        );
+        assert_eq!(analysis.policyai_errors, deserialized.policyai_errors);
+        assert_eq!(analysis.baseline_errors, deserialized.baseline_errors);
+    }
+}

--- a/src/bin/policyai-regression-report.rs
+++ b/src/bin/policyai-regression-report.rs
@@ -1,0 +1,407 @@
+//! Generate regression analysis reports from PolicyAI evaluation data.
+//!
+//! This binary reads evaluation reports and generates comprehensive regression analysis
+//! using confusion matrices and metrics to compare PolicyAI performance against baselines.
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read};
+
+use arrrg::CommandLine;
+use policyai::analysis::{ConfusionMatrix, FieldMatchAccuracyMatrix, RegressionAnalysis};
+use policyai::data::EvaluationReport;
+
+#[derive(Clone, Default, Debug, Eq, PartialEq, arrrg_derive::CommandLine)]
+struct Args {
+    #[arrrg(flag, "Print detailed metrics for each field")]
+    verbose: bool,
+    #[arrrg(optional, "Output format (json, csv, text)")]
+    format: Option<String>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (args, free) = Args::from_command_line_relaxed(
+        "USAGE: policyai-regression-report [OPTIONS] [input_file...]",
+    );
+
+    let reports = if free.is_empty() {
+        read_from_stdin()?
+    } else {
+        read_from_files(&free)?
+    };
+
+    if reports.is_empty() {
+        eprintln!("No evaluation reports found in input");
+        return Ok(());
+    }
+
+    let mut analysis = RegressionAnalysis::new();
+    let mut accuracy_matrix = FieldMatchAccuracyMatrix::new();
+
+    for report in &reports {
+        analysis.add_report(&report.metrics);
+
+        let expected_field_count = report
+            .input
+            .expected
+            .as_ref()
+            .and_then(|v| v.as_object())
+            .map(|obj| obj.len())
+            .unwrap_or(0);
+
+        accuracy_matrix.add_report(&report.metrics, expected_field_count);
+    }
+
+    match args.format.as_deref().unwrap_or("text") {
+        "json" => print_json(&analysis, &accuracy_matrix, &reports)?,
+        "csv" => print_csv(&analysis, &accuracy_matrix)?,
+        "text" => print_text(&analysis, &accuracy_matrix, &reports, args.verbose)?,
+        _ => print_text(&analysis, &accuracy_matrix, &reports, args.verbose)?,
+    }
+
+    Ok(())
+}
+
+fn print_json(
+    analysis: &RegressionAnalysis,
+    accuracy_matrix: &FieldMatchAccuracyMatrix,
+    _reports: &[EvaluationReport],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = serde_json::json!({
+        "summary": {
+            "total_reports": analysis.total_reports,
+            "policyai": {
+                "avg_fields_matched": analysis.policyai_avg_fields_matched(),
+                "total_wrong_values": analysis.policyai_total_wrong_values,
+                "total_missing_fields": analysis.policyai_total_missing_fields,
+                "total_extra_fields": analysis.policyai_total_extra_fields,
+                "error_rate": analysis.policyai_error_rate(),
+                "avg_duration_ms": analysis.policyai_avg_duration_ms(),
+            },
+            "baseline": {
+                "avg_fields_matched": analysis.baseline_avg_fields_matched(),
+                "total_wrong_values": analysis.baseline_total_wrong_values,
+                "total_missing_fields": analysis.baseline_total_missing_fields,
+                "total_extra_fields": analysis.baseline_total_extra_fields,
+                "error_rate": analysis.baseline_error_rate(),
+                "avg_duration_ms": analysis.baseline_avg_duration_ms(),
+            },
+            "comparison": {
+                "fields_matched_improvement": analysis.policyai_avg_fields_matched() - analysis.baseline_avg_fields_matched(),
+                "speed_ratio": if analysis.policyai_avg_duration_ms() > 0.0 {
+                    analysis.baseline_avg_duration_ms() / analysis.policyai_avg_duration_ms()
+                } else {
+                    0.0
+                },
+                "error_rate_difference": analysis.policyai_error_rate() - analysis.baseline_error_rate(),
+            },
+            "field_match_accuracy": {
+                "confusion_matrix": {
+                    "true_positive": accuracy_matrix.confusion_matrix.true_positive,
+                    "false_positive": accuracy_matrix.confusion_matrix.false_positive,
+                    "true_negative": accuracy_matrix.confusion_matrix.true_negative,
+                    "false_negative": accuracy_matrix.confusion_matrix.false_negative,
+                },
+                "metrics": {
+                    "precision": accuracy_matrix.confusion_matrix.precision(),
+                    "recall": accuracy_matrix.confusion_matrix.recall(),
+                    "f1_score": accuracy_matrix.confusion_matrix.f1_score(),
+                    "accuracy": accuracy_matrix.confusion_matrix.accuracy(),
+                }
+            }
+        }
+    });
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn print_csv(
+    analysis: &RegressionAnalysis,
+    accuracy_matrix: &FieldMatchAccuracyMatrix,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("metric,policyai_total,baseline_total,policyai_avg,baseline_avg,improvement");
+    println!(
+        "fields_matched,{},{},{:.4},{:.4},{:.4}",
+        analysis.policyai_total_fields_matched,
+        analysis.baseline_total_fields_matched,
+        analysis.policyai_avg_fields_matched(),
+        analysis.baseline_avg_fields_matched(),
+        analysis.policyai_avg_fields_matched() - analysis.baseline_avg_fields_matched()
+    );
+    println!(
+        "wrong_values,{},{},,,",
+        analysis.policyai_total_wrong_values, analysis.baseline_total_wrong_values
+    );
+    println!(
+        "missing_fields,{},{},,,",
+        analysis.policyai_total_missing_fields, analysis.baseline_total_missing_fields
+    );
+    println!(
+        "extra_fields,{},{},,,",
+        analysis.policyai_total_extra_fields, analysis.baseline_total_extra_fields
+    );
+    println!(
+        "errors,{},{},{:.4},{:.4},{:.4}",
+        analysis.policyai_errors,
+        analysis.baseline_errors,
+        analysis.policyai_error_rate(),
+        analysis.baseline_error_rate(),
+        analysis.policyai_error_rate() - analysis.baseline_error_rate()
+    );
+    println!(
+        "duration_ms,{},{},{:.2},{:.2},{:.2}",
+        analysis.policyai_total_duration_ms,
+        analysis.baseline_total_duration_ms,
+        analysis.policyai_avg_duration_ms(),
+        analysis.baseline_avg_duration_ms(),
+        if analysis.policyai_avg_duration_ms() > 0.0 {
+            analysis.baseline_avg_duration_ms() / analysis.policyai_avg_duration_ms()
+        } else {
+            0.0
+        }
+    );
+
+    println!("\nfield_match_accuracy_matrix,value");
+    println!(
+        "true_positive,{}",
+        accuracy_matrix.confusion_matrix.true_positive
+    );
+    println!(
+        "false_positive,{}",
+        accuracy_matrix.confusion_matrix.false_positive
+    );
+    println!(
+        "true_negative,{}",
+        accuracy_matrix.confusion_matrix.true_negative
+    );
+    println!(
+        "false_negative,{}",
+        accuracy_matrix.confusion_matrix.false_negative
+    );
+    println!(
+        "precision,{:.4}",
+        accuracy_matrix.confusion_matrix.precision()
+    );
+    println!("recall,{:.4}", accuracy_matrix.confusion_matrix.recall());
+    println!(
+        "f1_score,{:.4}",
+        accuracy_matrix.confusion_matrix.f1_score()
+    );
+    println!(
+        "accuracy,{:.4}",
+        accuracy_matrix.confusion_matrix.accuracy()
+    );
+
+    Ok(())
+}
+
+fn print_text(
+    analysis: &RegressionAnalysis,
+    accuracy_matrix: &FieldMatchAccuracyMatrix,
+    _reports: &[EvaluationReport],
+    verbose: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("PolicyAI Regression Analysis Report");
+    println!("===================================");
+    println!("Total evaluation reports: {}", analysis.total_reports);
+    println!();
+
+    println!("Performance Comparison:");
+    println!("----------------------");
+
+    println!("Fields Matched:");
+    println!(
+        "  PolicyAI avg: {:.2}",
+        analysis.policyai_avg_fields_matched()
+    );
+    println!(
+        "  Baseline avg: {:.2}",
+        analysis.baseline_avg_fields_matched()
+    );
+    println!(
+        "  Improvement:  {:.2}",
+        analysis.policyai_avg_fields_matched() - analysis.baseline_avg_fields_matched()
+    );
+    println!();
+
+    println!("Error Rates:");
+    println!(
+        "  PolicyAI: {:.1}% ({} errors)",
+        analysis.policyai_error_rate() * 100.0,
+        analysis.policyai_errors
+    );
+    println!(
+        "  Baseline: {:.1}% ({} errors)",
+        analysis.baseline_error_rate() * 100.0,
+        analysis.baseline_errors
+    );
+    println!(
+        "  Difference: {:.1} percentage points",
+        (analysis.policyai_error_rate() - analysis.baseline_error_rate()) * 100.0
+    );
+    println!();
+
+    println!("Performance:");
+    println!(
+        "  PolicyAI avg duration: {:.2} ms",
+        analysis.policyai_avg_duration_ms()
+    );
+    println!(
+        "  Baseline avg duration: {:.2} ms",
+        analysis.baseline_avg_duration_ms()
+    );
+    if analysis.policyai_avg_duration_ms() > 0.0 {
+        let speed_ratio = analysis.baseline_avg_duration_ms() / analysis.policyai_avg_duration_ms();
+        println!("  Speed ratio (baseline/policyai): {:.2}x", speed_ratio);
+    }
+    println!();
+
+    println!("Field Quality:");
+    println!("Wrong Values:");
+    println!("  PolicyAI total: {}", analysis.policyai_total_wrong_values);
+    println!("  Baseline total: {}", analysis.baseline_total_wrong_values);
+    println!();
+
+    println!("Missing Fields:");
+    println!(
+        "  PolicyAI total: {}",
+        analysis.policyai_total_missing_fields
+    );
+    println!(
+        "  Baseline total: {}",
+        analysis.baseline_total_missing_fields
+    );
+    println!();
+
+    println!("Extra Fields:");
+    println!("  PolicyAI total: {}", analysis.policyai_total_extra_fields);
+    println!("  Baseline total: {}", analysis.baseline_total_extra_fields);
+    println!();
+
+    // Display confusion matrix for field matching accuracy
+    print_confusion_matrix_text(
+        "Field Match Accuracy (PolicyAI vs Baseline)",
+        &accuracy_matrix.confusion_matrix,
+    );
+
+    if verbose {
+        println!("Additional Details:");
+        println!("------------------");
+        println!("Total Duration:");
+        println!(
+            "  PolicyAI total: {} ms",
+            analysis.policyai_total_duration_ms
+        );
+        println!(
+            "  Baseline total: {} ms",
+            analysis.baseline_total_duration_ms
+        );
+        println!();
+    }
+
+    Ok(())
+}
+
+fn print_confusion_matrix_text(name: &str, matrix: &ConfusionMatrix) {
+    println!("{}:", name);
+
+    // Print confusion matrix in tabular format
+    let tp = matrix.true_positive;
+    let fp = matrix.false_positive;
+    let tn = matrix.true_negative;
+    let fn_val = matrix.false_negative;
+
+    // Calculate column widths for alignment
+    let values = [tp, fp, tn, fn_val];
+    let max_val = values.iter().max().unwrap();
+    let val_width = format!("{}", max_val).len().max(4);
+
+    println!("  Confusion Matrix:");
+    println!("                     │ PolicyAI");
+    println!(
+        "                     │ {:>width$} {:>width$}",
+        "Correct",
+        "Wrong",
+        width = val_width + 8
+    );
+    println!(
+        "    ─────────────────┼{:─<width$}─{:─<width$}──",
+        "",
+        "",
+        width = val_width + 8
+    );
+    let total = tp + fp + tn + fn_val;
+    println!(
+        "    Baseline Correct │ {:>width$} {:>width$}",
+        format!("{} ({:.1}%)", tp, 100.0 * tp as f64 / total as f64),
+        format!("{} ({:.1}%)", fn_val, 100.0 * fn_val as f64 / total as f64),
+        width = val_width + 8 // Add space for percentage
+    );
+    println!(
+        "               Wrong │ {:>width$} {:>width$}",
+        format!("{} ({:.1}%)", fp, 100.0 * fp as f64 / total as f64),
+        format!("{} ({:.1}%)", tn, 100.0 * tn as f64 / total as f64),
+        width = val_width + 8
+    );
+    println!();
+
+    // Print metrics
+    println!("  Metrics:");
+    println!(
+        "    Precision: {:.4} (when PolicyAI says correct, how often is it right)",
+        matrix.precision()
+    );
+    println!(
+        "    Recall:    {:.4} (when baseline is correct, how often does PolicyAI get it right)",
+        matrix.recall()
+    );
+    println!("    F1 Score:  {:.4}", matrix.f1_score());
+    println!(
+        "    Accuracy:  {:.4} (overall agreement rate)",
+        matrix.accuracy()
+    );
+
+    println!();
+}
+
+fn read_from_stdin() -> Result<Vec<EvaluationReport>, Box<dyn std::error::Error>> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+
+    let reports: Vec<EvaluationReport> = input
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(serde_json::from_str)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(reports)
+}
+
+fn read_from_files(files: &[String]) -> Result<Vec<EvaluationReport>, Box<dyn std::error::Error>> {
+    let mut reports = Vec::new();
+
+    for file_path in files {
+        let file = File::open(file_path)?;
+        let reader = BufReader::new(file);
+
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let report: EvaluationReport = match serde_json::from_str(&line) {
+                Ok(report) => report,
+                Err(e) => {
+                    eprintln!(
+                        "Warning: Failed to parse line in {file_path} as EvaluationReport: {e}"
+                    );
+                    continue;
+                }
+            };
+
+            reports.push(report);
+        }
+    }
+
+    Ok(reports)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@ use std::cmp::Ordering;
 /// Data structures and utilities for test data
 pub mod data;
 
+/// Analysis tools for evaluation metrics
+pub mod analysis;
+
 mod errors;
 mod field;
 mod manager;


### PR DESCRIPTION
Create new regression analysis tool that compares PolicyAI vs baseline
performance across multiple metrics:

Analysis capabilities:
- RegressionAnalysis: aggregates field matching, error rates, and timing data
- FieldMatchAccuracyMatrix: confusion matrix comparing expected field count accuracy
- Support for stdin input or multiple file arguments

Output formats:
- Text: formatted tables with performance comparison and confusion matrix
- JSON: structured data with all metrics and comparisons
- CSV: tabular format suitable for spreadsheet analysis

Key metrics tracked:
- Field matching averages and totals
- Wrong values, missing fields, extra fields
- Error rates and counts with percentage breakdowns
- Performance timing and speed ratios
- Confusion matrix with precision/recall/F1/accuracy

The confusion matrix specifically measures whether PolicyAI vs baseline
correctly matches the expected field count from input.expected.keys(),
providing actionable insight into field extraction accuracy.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-by: Claude <noreply@anthropic.com>
