### PR TITLE
feat: make mask values nullable and add conflict reporting

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -700,7 +700,17 @@ impl Report {
         });
     }
 
-    fn report_number_conflict(
+    /// Report a conflict between two numeric values for the same field.
+    ///
+    /// Records a conflict when multiple policies specify different numeric values
+    /// for the same field, enabling conflict detection and resolution reporting.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The name of the field experiencing the conflict
+    /// * `val1` - The first conflicting numeric value
+    /// * `val2` - The second conflicting numeric value
+    pub fn report_number_conflict(
         &mut self,
         field: &str,
         val1: serde_json::Number,
@@ -713,7 +723,36 @@ impl Report {
         });
     }
 
-    fn report_string_conflict(&mut self, field: &str, val1: String, val2: String) {
+    /// Report a conflict between two string values for the same field.
+    ///
+    /// Records a conflict when multiple policies specify different string values
+    /// for the same field, enabling conflict detection and resolution reporting.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The name of the field experiencing the conflict
+    /// * `val1` - The first conflicting string value
+    /// * `val2` - The second conflicting string value
+    pub fn report_string_conflict(&mut self, field: &str, val1: String, val2: String) {
+        self.conflicts.push(Conflict::StringConflict {
+            field: field.to_string(),
+            val1,
+            val2,
+        });
+    }
+
+    /// Report a conflict between a boolean flag and expected enum value.
+    ///
+    /// Records a conflict when a string enum field receives a boolean value
+    /// that doesn't match the expected enum value, enabling conflict detection
+    /// and resolution reporting.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The name of the field experiencing the conflict
+    /// * `val1` - The existing string value from the report
+    /// * `val2` - The expected enum string value
+    pub fn report_string_enum_conflict(&mut self, field: &str, val1: String, val2: String) {
         self.conflicts.push(Conflict::StringConflict {
             field: field.to_string(),
             val1,


### PR DESCRIPTION
Change NumberMask, StringMask, and StringEnumMask to accept Option<T>
instead of T for their value fields, allowing policies to specify
null values. Add corresponding conflict reporting methods to Report:

- NumberMask.value: serde_json::Number -> Option<serde_json::Number>
- StringMask.value: String -> Option<String>
- StringEnumMask.value: String -> Option<String>

New public conflict reporting methods:
- Report::report_number_conflict()
- Report::report_string_conflict()
- Report::report_string_enum_conflict()

Update ReportBuilder to handle null values in policy fields and
generate appropriate default returns. Fix all documentation tests
to use correct Option wrappers in examples.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-by: Claude <noreply@anthropic.com>
