### PR TITLE
chore: update claudius dependency to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rescrv/policyai"
 [dependencies]
 arrrg = "0.6.0"
 arrrg_derive = "0.6.0"
-claudius = "0.13.0"
+claudius = "0.14.0"
 getopts = "0.2.21"
 guacamole = "0.10.0"
 rand = "0.9.0"


### PR DESCRIPTION
Update claudius crate from version 0.13.0 to 0.14.0 to ensure
compatibility with latest API changes and bug fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
