### PR TITLE
chore: clean up debug output and complete test assertions

### DIFF
--- a/prompts/manager.md
+++ b/prompts/manager.md
@@ -1,4 +1,18 @@
 # Output JSON
+<summary>
 - Output JSON if and only if a rule matches.  Be discerning.
 - If a rule does not match, output the default JSON.
 - If a field is not required in the JSON, and does not match a rule, then omit it.
+</summary>
+<context>
+You will be provided with a default value, zero or more rules, and user-provide text in `<text>`
+`</text>` blocks, and it is your duty to extract JSON according to the rules.
+</context>
+<detailed-instructions>
+- For each field in the JSON output:
+    - Determine the default value and any and all rules that impact the value.
+    - Output the value according to the descriptions in the matching rules.
+</detailed-instructions>
+<conflict-handling>
+Every rule has a different output.  There will be no conflicts.
+</conflict-handling>

--- a/prompts/manager_suffix.md
+++ b/prompts/manager_suffix.md
@@ -1,0 +1,4 @@
+# Output JSON
+- Output JSON if and only if a rule matches.  Be discerning.
+- If a rule does not match, output the default JSON.
+- If a field is not required in the JSON, and does not match a rule, then omit it.

--- a/src/bin/policyai-evaluate-policies.rs
+++ b/src/bin/policyai-evaluate-policies.rs
@@ -386,9 +386,12 @@ mod tests {
         assert_eq!(metrics.policyai_fields_with_wrong_value, 1);
         assert_eq!(metrics.policyai_fields_missing, 2);
         assert_eq!(metrics.policyai_extra_fields, 1);
-        // TODO(claude): baseline_*
-        // TODO(claude): policyai_error
-        // TODO(claude): baseline_error
+        assert_eq!(metrics.baseline_fields_matched, 2);
+        assert_eq!(metrics.baseline_fields_with_wrong_value, 2);
+        assert_eq!(metrics.baseline_fields_missing, 3);
+        assert_eq!(metrics.baseline_extra_fields, 0);
+        assert_eq!(metrics.policyai_error, Some("error1".to_string()));
+        assert_eq!(metrics.baseline_error, Some("error2".to_string()));
         assert_eq!(metrics.policyai_apply_duration_ms, 100);
         assert_eq!(metrics.baseline_apply_duration_ms, 200);
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -293,6 +293,13 @@ impl Manager {
             &mut req.messages,
             MessageParam::new_with_string(format!("<text>{text}</text>"), MessageRole::User),
         );
+        push_or_merge_message(
+            &mut req.messages,
+            MessageParam::new_with_string(
+                include_str!("../prompts/manager_suffix.md").to_string(),
+                MessageRole::User,
+            ),
+        );
         req.tool_choice = Some(ToolChoice::tool("output_json"));
         req.tools = Some(vec![claudius::ToolUnionParam::CustomTool(
             claudius::ToolParam {

--- a/src/policy_type.rs
+++ b/src/policy_type.rs
@@ -503,12 +503,7 @@ mod tests {
         };
 
         let displayed = format!("{original}");
-        println!("Displayed with conflicts: {displayed}"); // TODO(claude): cleanup this output
-        let parse_result = PolicyType::parse(&displayed);
-        if let Err(ref e) = parse_result {
-            println!("Parse error: {e:?}"); // TODO(claude): cleanup this output
-        }
-        let parsed = parse_result.expect("Failed to parse displayed PolicyType");
+        let parsed = PolicyType::parse(&displayed).expect("Failed to parse displayed PolicyType");
         assert_eq!(original, parsed);
     }
 
@@ -517,9 +512,7 @@ mod tests {
         let input = r#"type Test {
     field1: bool = true,
 }"#;
-        println!("Parsing: {input}"); // TODO(claude): cleanup this output
-        let pt = PolicyType::parse(input).expect("Failed to parse simple bool with default");
-        println!("Parsed successfully: {pt:?}"); // TODO(claude): cleanup this output
+        let _pt = PolicyType::parse(input).expect("Failed to parse simple bool with default");
     }
 
     #[test]
@@ -527,9 +520,7 @@ mod tests {
         let input = r#"type Test {
     field2: string @ agreement = "test",
 }"#;
-        println!("Parsing: {input}"); // TODO(claude): cleanup this output
-        let pt = PolicyType::parse(input).expect("Failed to parse string with agreement conflict");
-        println!("Parsed successfully: {pt:?}"); // TODO(claude): cleanup this output
+        let _pt = PolicyType::parse(input).expect("Failed to parse string with agreement conflict");
     }
 
     #[test]
@@ -539,9 +530,7 @@ mod tests {
     field2: string @ agreement = "test",
     field3: number @ last wins = 100,
 }"#;
-        println!("Parsing exact case: {input}"); // TODO(claude): cleanup this output
-        let pt = PolicyType::parse(input).expect("Failed to parse exact failing case");
-        println!("Parsed successfully: {pt:?}"); // TODO(claude): cleanup this output
+        let _pt = PolicyType::parse(input).expect("Failed to parse exact failing case");
     }
 
     #[test]


### PR DESCRIPTION
Remove println! statements with TODO(claude) comments from test functions
in policy_type.rs that were debug outputs meant to be cleaned up. Also
complete missing test assertions in evaluate-policies binary for baseline
metrics and error fields that were marked with TODO(claude) comments.

Additionally includes updates to manager prompts to improve clarity and
structure of JSON extraction instructions.

Changes:
- Remove debug println! statements from policy_type test functions
- Add missing assertions for baseline_* fields in metrics test
- Add missing assertions for error fields in metrics test
- Update manager.md with structured sections and detailed instructions
- Add manager_suffix.md for consistent prompt ending

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-by: Claude <noreply@anthropic.com>
