### PR TITLE
chore: bump all dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,17 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/policyai"
 
 [dependencies]
-arrrg = "0.6.0"
-arrrg_derive = "0.6.0"
-claudius = "0.16.0"
-getopts = "0.2.21"
-guacamole = "0.10.0"
-rand = "0.9.0"
-reqwest = "0.12.12"
-rustyline = { version = "15.0.0", features = ["derive"] }
-serde = "1.0.217"
-serde_json = { version = "1.0.135", features = ["preserve_order"] }
-shvar = "0.6.0"
-tokio = { version = "1.43.0", features = ["rt", "macros"] }
-utf8path = "0.9.1"
+arrrg = "0.10.0"
+arrrg_derive = "0.10.0"
+claudius = "0.31.0"
+getopts = "0.2.24"
+guacamole = "0.16.0"
+rand = "0.10.1"
+reqwest = "0.13.4"
+rustyline = { version = "18.0.0", features = ["derive"] }
+serde = "1.0.228"
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
+shvar = "0.10.0"
+tokio = { version = "1.52.3", features = ["rt", "macros"] }
+utf8path = "0.11.0"
 uuid = { version = "1.18.1", features = ["v4"] }

--- a/examples/generate-semantic-injections.rs
+++ b/examples/generate-semantic-injections.rs
@@ -82,8 +82,11 @@ Text:
             let req = claudius::MessageCreateParams {
                 max_tokens: 2048,
                 messages: vec![prompt.into()],
-                model: Model::Known(KnownModel::ClaudeSonnet40),
+                model: Model::Known(KnownModel::ClaudeOpus48),
+                cache_control: None,
                 metadata: None,
+                output_config: None,
+                output_format: None,
                 stop_sequences: None,
                 system: Some(SystemPrompt::from_blocks(vec![TextBlock {
                     text: system.to_string(),
@@ -97,6 +100,7 @@ Text:
                 top_k: None,
                 top_p: None,
                 stream: false,
+                betas: None,
             };
             let resp = client.send(req).await?;
             let mut injection = String::new();

--- a/examples/generate-test-data.rs
+++ b/examples/generate-test-data.rs
@@ -243,7 +243,7 @@ fn generate_conflict_test_case(
     // Decide how many fields to create conflicts for (at least 1, up to all)
     let num_conflict_fields = rng.random_range(1..=agreement_fields.len());
     let selected_fields: Vec<_> = agreement_fields
-        .choose_multiple(rng, num_conflict_fields)
+        .sample(rng, num_conflict_fields)
         .cloned()
         .collect();
 

--- a/src/bin/policyai-evaluate-policies.rs
+++ b/src/bin/policyai-evaluate-policies.rs
@@ -3,8 +3,8 @@ use std::io::{BufRead, BufReader};
 use std::time::Instant;
 
 use claudius::{
-    push_or_merge_message, Anthropic, ContentBlock, JsonSchema, MessageCreateParams, MessageParam,
-    MessageRole, Metadata, Model, SystemPrompt, TextBlock, ToolChoice,
+    push_or_merge_message, Anthropic, ContentBlock, JsonSchema, KnownModel, MessageCreateParams,
+    MessageParam, MessageRole, Metadata, Model, SystemPrompt, TextBlock, ToolChoice,
 };
 
 use policyai::data::{EvaluationReport, Metrics, TestDataPoint};
@@ -104,6 +104,7 @@ pub async fn naive_apply(
             description: Some("output JSON according to policy".to_string()),
             input_schema: schema,
             cache_control: None,
+            strict: None,
         },
     )]);
     let start_time = Instant::now();
@@ -273,7 +274,7 @@ async fn main() {
                 &point.policies,
                 &MessageCreateParams {
                     max_tokens: 4096,
-                    model: Model::Custom("claude-sonnet-4-5".to_string()),
+                    model: Model::Known(KnownModel::ClaudeOpus48),
                     ..Default::default()
                 },
                 &point.text,
@@ -308,7 +309,7 @@ async fn main() {
                     &client,
                     MessageCreateParams {
                         max_tokens: 4096,
-                        model: Model::Custom("claude-sonnet-4-5".to_string()),
+                        model: Model::Known(KnownModel::ClaudeOpus48),
                         ..Default::default()
                     },
                     &point.text,

--- a/src/data.rs
+++ b/src/data.rs
@@ -172,7 +172,8 @@ Output just this one-word answer
         .to_string();
         let req = MessageCreateParams {
             max_tokens: 1030,
-            model: Model::Known(KnownModel::ClaudeSonnet40),
+            model: Model::Known(KnownModel::ClaudeOpus48),
+            cache_control: None,
             system: Some(SystemPrompt::from_blocks(vec![TextBlock {
                 text: system.to_string(),
                 cache_control: Some(CacheControlEphemeral::new()),
@@ -197,11 +198,14 @@ Output just this one-word answer
             thinking: Some(ThinkingConfig::enabled(1024)),
             stream: false,
             metadata: None,
+            output_config: None,
+            output_format: None,
             temperature: None,
             tools: None,
             tool_choice: None,
             top_p: None,
             top_k: None,
+            betas: None,
         };
         let resp = client.send(req).await?;
         if !matches!(resp.stop_reason, Some(StopReason::StopSequence)) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,9 +40,9 @@ pub enum PolicyError {
         /// Name of the field with conflicting defaults.
         field: String,
         /// The existing default value.
-        existing: serde_json::Value,
+        existing: Box<serde_json::Value>,
         /// The new default value that conflicts.
-        new: serde_json::Value,
+        new: Box<serde_json::Value>,
         /// Suggested resolution for the conflict.
         suggestion: String,
     },
@@ -240,9 +240,9 @@ pub enum Conflict {
         /// Name of the field experiencing the disagreement.
         name: String,
         /// First value from one policy.
-        value1: serde_json::Value,
+        value1: Box<serde_json::Value>,
         /// Second value from another policy.
-        value2: serde_json::Value,
+        value2: Box<serde_json::Value>,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub(crate) fn number_less_than(lhs: &serde_json::Number, rhs: &serde_json::Numbe
 
 #[cfg(test)]
 mod tests {
-    use claudius::{Anthropic, MessageCreateParams};
+    use claudius::{Anthropic, KnownModel, MessageCreateParams, Model};
 
     use super::*;
 
@@ -407,6 +407,7 @@ mod tests {
                 &Anthropic::new(None).unwrap(),
                 MessageCreateParams {
                     max_tokens: 2048,
+                    model: Model::Known(KnownModel::ClaudeOpus48),
                     ..Default::default()
                 },
                 r#"From: robert@example.org

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -32,7 +32,7 @@ use crate::{ApplyError, Policy, Report, ReportBuilder, Usage};
 ///
 /// # let template = MessageCreateParams {
 /// #     max_tokens: 1024,
-/// #     model: Model::Known(KnownModel::ClaudeSonnet40),
+/// #     model: Model::Known(KnownModel::ClaudeOpus48),
 /// #     messages: vec![],
 /// #     ..Default::default()
 /// # };
@@ -302,6 +302,7 @@ impl Manager {
                 description: Some("output JSON".to_string()),
                 input_schema: report.schema(),
                 cache_control: None,
+                strict: None,
             },
         )]);
         Ok((report, req))

--- a/src/masks.rs
+++ b/src/masks.rs
@@ -439,7 +439,7 @@ impl StringArrayMask {
             } else if let serde_json::Value::Array(a) = value {
                 let mut all = vec![];
                 for v in a {
-                    all.extend(extract_strings(v, depth - 1)?.into_iter());
+                    all.extend(extract_strings(v, depth - 1)?);
                 }
                 Some(all)
             } else {

--- a/src/policy_type.rs
+++ b/src/policy_type.rs
@@ -105,7 +105,8 @@ impl PolicyType {
         let system = include_str!("../prompts/generate-semantic-injection.md").to_string();
         let req = MessageCreateParams {
             max_tokens: 2048,
-            model: Model::Known(KnownModel::ClaudeSonnet40),
+            model: Model::Known(KnownModel::ClaudeOpus48),
+            cache_control: None,
             messages: vec![MessageParam::new_with_string(
                 format!("<ask>{injection}</ask>"),
                 MessageRole::User,
@@ -113,6 +114,8 @@ impl PolicyType {
             system: Some(system.into()),
             thinking: Some(ThinkingConfig::enabled(1024)),
             metadata: None,
+            output_config: None,
+            output_format: None,
             stop_sequences: None,
             temperature: None,
             tool_choice: None,
@@ -120,6 +123,7 @@ impl PolicyType {
             top_k: None,
             top_p: None,
             stream: false,
+            betas: None,
         };
         let resp = client.send(req).await?;
         let prompt = injection.to_string();

--- a/src/report.rs
+++ b/src/report.rs
@@ -186,8 +186,8 @@ impl Report {
             if *existing != serde_json::Value::Bool(default) {
                 self.errors.push(PolicyError::DefaultConflict {
                     field: field.to_string(),
-                    existing: existing.clone(),
-                    new: serde_json::Value::Bool(default),
+                    existing: Box::new(existing.clone()),
+                    new: Box::new(serde_json::Value::Bool(default)),
                     suggestion: "Ensure all policies use the same default value for this field"
                         .to_string(),
                 });
@@ -304,8 +304,8 @@ impl Report {
             if *existing != serde_json::Value::Number(default.clone()) {
                 self.errors.push(PolicyError::DefaultConflict {
                     field: field.to_string(),
-                    existing: existing.clone(),
-                    new: serde_json::Value::Number(default),
+                    existing: Box::new(existing.clone()),
+                    new: Box::new(serde_json::Value::Number(default)),
                     suggestion: "Ensure all policies use the same default value for this field"
                         .to_string(),
                 });
@@ -425,8 +425,8 @@ impl Report {
             if *existing != serde_json::Value::String(default.clone()) {
                 self.errors.push(PolicyError::DefaultConflict {
                     field: field.to_string(),
-                    existing: existing.clone(),
-                    new: serde_json::Value::String(default),
+                    existing: Box::new(existing.clone()),
+                    new: Box::new(serde_json::Value::String(default)),
                     suggestion: "Ensure all policies use the same default value for this field"
                         .to_string(),
                 });


### PR DESCRIPTION
Update all dependencies in Cargo.toml to their latest versions,
most notably claudius 0.14 -> 0.30, arrrg/shvar 0.6 -> 0.10,
guacamole 0.10 -> 0.16, rand 0.9 -> 0.10, reqwest 0.12 -> 0.13,
rustyline 15 -> 18, and utf8path 0.9 -> 0.11.

Adapt to breaking API changes in upstream crates:
- Add cache_control, output_config, output_format fields to
  MessageCreateParams (claudius 0.30)
- Add strict field to ToolDefinition (claudius 0.30)
- Rename choose_multiple to sample (rand 0.10)
- Box large serde_json::Value fields in PolicyError and Conflict
  enums to satisfy clippy::large_enum_variant
- Use Opus 4.8 for everything

Co-authored-by: AI
