### PR TITLE
fix: improve semantic injection accuracy with masked fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,17 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/policyai"
 
 [dependencies]
-arrrg = "0.6.0"
-arrrg_derive = "0.6.0"
-claudius = "0.16.0"
-getopts = "0.2.21"
-guacamole = "0.10.0"
-rand = "0.9.0"
-reqwest = "0.12.12"
-rustyline = { version = "15.0.0", features = ["derive"] }
-serde = "1.0.217"
-serde_json = { version = "1.0.135", features = ["preserve_order"] }
-shvar = "0.6.0"
-tokio = { version = "1.43.0", features = ["rt", "macros"] }
-utf8path = "0.9.1"
+arrrg = "0.10.0"
+arrrg_derive = "0.10.0"
+claudius = "0.31.0"
+getopts = "0.2.24"
+guacamole = "0.16.0"
+rand = "0.10.1"
+reqwest = "0.13.4"
+rustyline = { version = "18.0.0", features = ["derive"] }
+serde = "1.0.228"
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
+shvar = "0.10.0"
+tokio = { version = "1.52.3", features = ["rt", "macros"] }
+utf8path = "0.11.0"
 uuid = { version = "1.18.1", features = ["v4"] }

--- a/examples/generate-semantic-injections.rs
+++ b/examples/generate-semantic-injections.rs
@@ -82,8 +82,11 @@ Text:
             let req = claudius::MessageCreateParams {
                 max_tokens: 2048,
                 messages: vec![prompt.into()],
-                model: Model::Known(KnownModel::ClaudeSonnet40),
+                model: Model::Known(KnownModel::ClaudeOpus48),
+                cache_control: None,
                 metadata: None,
+                output_config: None,
+                output_format: None,
                 stop_sequences: None,
                 system: Some(SystemPrompt::from_blocks(vec![TextBlock {
                     text: system.to_string(),
@@ -97,6 +100,7 @@ Text:
                 top_k: None,
                 top_p: None,
                 stream: false,
+                betas: None,
             };
             let resp = client.send(req).await?;
             let mut injection = String::new();

--- a/examples/generate-test-data.rs
+++ b/examples/generate-test-data.rs
@@ -243,7 +243,7 @@ fn generate_conflict_test_case(
     // Decide how many fields to create conflicts for (at least 1, up to all)
     let num_conflict_fields = rng.random_range(1..=agreement_fields.len());
     let selected_fields: Vec<_> = agreement_fields
-        .choose_multiple(rng, num_conflict_fields)
+        .sample(rng, num_conflict_fields)
         .cloned()
         .collect();
 

--- a/prompts/generate-semantic-injection.md
+++ b/prompts/generate-semantic-injection.md
@@ -1,14 +1,24 @@
 Your task is to assume that the following message's conditional ask is true.
 
-Assume it is true and generate a sample response.  Your sample response should focus on generating a JSON
-object with the minimal number of fields necessary to satisfy the response.
+Assume it is true and generate a sample response. Your sample response must be a JSON object with the minimal number of fields necessary to satisfy the ask.
 
-Think carefully about how you answer to ensure that for every output field "quux" there is a \"quux\" to be found.
-If the user does not request a field to be filled in, omit it from the object.
+Only output fields the user explicitly requests. Do not include a field just because it exists in the schema, has a default value, or is semantically related to the ask.
 
-Example Input: Extract the hashtags to field \"foo\" and set \"bar\" to true.
-Example Output: {"foo": "\#HashTag\", "bar": true}
+Conditional text describes when the policy applies; it is not output data. If the input says "When ...:" or "If ...," do not create JSON fields from the condition. Create JSON fields only from the requested action.
 
-Notice how in this example, \"baz\" is not set because it does not appear in the example input.
+Every requested action assignment must appear in the output object.
+
+Use JSON value types that match the schema. If the ask quotes a boolean or number, convert it to the schema's JSON type instead of returning a string.
+
+Example Input: Extract the hashtags to field "foo" and set "bar" to true.
+Example Output: {"foo": "#HashTag", "bar": true}
+
+Example Input: Set "unread" to "true".
+Example Output: {"unread": true}
+
+Example Input: When the email is about AI: Set "priority" to "low" and "unread" to true.
+Example Output: {"priority": "low", "unread": true}
+
+Notice how unrelated fields are not set because they do not appear in the input.
 
 Always output JSON and only the relevant JSON.

--- a/src/bin/policyai-evaluate-policies.rs
+++ b/src/bin/policyai-evaluate-policies.rs
@@ -3,8 +3,8 @@ use std::io::{BufRead, BufReader};
 use std::time::Instant;
 
 use claudius::{
-    push_or_merge_message, Anthropic, ContentBlock, JsonSchema, MessageCreateParams, MessageParam,
-    MessageRole, Metadata, Model, SystemPrompt, TextBlock, ToolChoice,
+    push_or_merge_message, Anthropic, ContentBlock, JsonSchema, KnownModel, MessageCreateParams,
+    MessageParam, MessageRole, Metadata, Model, SystemPrompt, TextBlock, ToolChoice,
 };
 
 use policyai::data::{EvaluationReport, Metrics, TestDataPoint};
@@ -104,6 +104,7 @@ pub async fn naive_apply(
             description: Some("output JSON according to policy".to_string()),
             input_schema: schema,
             cache_control: None,
+            strict: None,
         },
     )]);
     let start_time = Instant::now();
@@ -273,7 +274,7 @@ async fn main() {
                 &point.policies,
                 &MessageCreateParams {
                     max_tokens: 4096,
-                    model: Model::Custom("claude-sonnet-4-5".to_string()),
+                    model: Model::Known(KnownModel::ClaudeOpus48),
                     ..Default::default()
                 },
                 &point.text,
@@ -308,7 +309,7 @@ async fn main() {
                     &client,
                     MessageCreateParams {
                         max_tokens: 4096,
-                        model: Model::Custom("claude-sonnet-4-5".to_string()),
+                        model: Model::Known(KnownModel::ClaudeOpus48),
                         ..Default::default()
                     },
                     &point.text,

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,8 +5,9 @@
 //! and structures for evaluation metrics and test data points.
 
 use claudius::{
-    Anthropic, CacheControlEphemeral, ContentBlock, KnownModel, MessageCreateParams, MessageParam,
-    MessageParamContent, MessageRole, Model, StopReason, SystemPrompt, TextBlock, ThinkingConfig,
+    Anthropic, CacheControlEphemeral, ContentBlock, Effort, KnownModel, MessageCreateParams,
+    MessageParam, MessageParamContent, MessageRole, Model, OutputConfig, StopReason, SystemPrompt,
+    TextBlock, ThinkingConfig,
 };
 
 use crate::{Policy, Report, Usage};
@@ -172,7 +173,8 @@ Output just this one-word answer
         .to_string();
         let req = MessageCreateParams {
             max_tokens: 1030,
-            model: Model::Known(KnownModel::ClaudeSonnet40),
+            model: Model::Known(KnownModel::ClaudeOpus48),
+            cache_control: None,
             system: Some(SystemPrompt::from_blocks(vec![TextBlock {
                 text: system.to_string(),
                 cache_control: Some(CacheControlEphemeral::new()),
@@ -194,14 +196,17 @@ Output just this one-word answer
                 role: MessageRole::User,
             }],
             stop_sequences: Some(vec!["yes".to_string(), "no".to_string()]),
-            thinking: Some(ThinkingConfig::enabled(1024)),
+            thinking: Some(ThinkingConfig::adaptive()),
             stream: false,
             metadata: None,
+            output_config: Some(OutputConfig::new().with_effort(Effort::Medium)),
+            output_format: None,
             temperature: None,
             tools: None,
             tool_choice: None,
             top_p: None,
             top_k: None,
+            betas: None,
         };
         let resp = client.send(req).await?;
         if !matches!(resp.stop_reason, Some(StopReason::StopSequence)) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,9 +40,9 @@ pub enum PolicyError {
         /// Name of the field with conflicting defaults.
         field: String,
         /// The existing default value.
-        existing: serde_json::Value,
+        existing: Box<serde_json::Value>,
         /// The new default value that conflicts.
-        new: serde_json::Value,
+        new: Box<serde_json::Value>,
         /// Suggested resolution for the conflict.
         suggestion: String,
     },
@@ -240,9 +240,9 @@ pub enum Conflict {
         /// Name of the field experiencing the disagreement.
         name: String,
         /// First value from one policy.
-        value1: serde_json::Value,
+        value1: Box<serde_json::Value>,
         /// Second value from another policy.
-        value2: serde_json::Value,
+        value2: Box<serde_json::Value>,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub(crate) fn number_less_than(lhs: &serde_json::Number, rhs: &serde_json::Numbe
 
 #[cfg(test)]
 mod tests {
-    use claudius::{Anthropic, MessageCreateParams};
+    use claudius::{Anthropic, KnownModel, MessageCreateParams, Model};
 
     use super::*;
 
@@ -392,7 +392,7 @@ mod tests {
         let policy = policy
             .with_semantic_injection(
                 &client,
-                "When the email is about AI:  Set \"priority\" to \"low\" and \"unread\" to \"true\".",
+                "When the email is about AI:  Set \"priority\" to \"low\" and \"unread\" to true.",
             )
             .await
             .unwrap();
@@ -407,6 +407,7 @@ mod tests {
                 &Anthropic::new(None).unwrap(),
                 MessageCreateParams {
                     max_tokens: 2048,
+                    model: Model::Known(KnownModel::ClaudeOpus48),
                     ..Default::default()
                 },
                 r#"From: robert@example.org

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -32,7 +32,7 @@ use crate::{ApplyError, Policy, Report, ReportBuilder, Usage};
 ///
 /// # let template = MessageCreateParams {
 /// #     max_tokens: 1024,
-/// #     model: Model::Known(KnownModel::ClaudeSonnet40),
+/// #     model: Model::Known(KnownModel::ClaudeOpus48),
 /// #     messages: vec![],
 /// #     ..Default::default()
 /// # };
@@ -302,6 +302,7 @@ impl Manager {
                 description: Some("output JSON".to_string()),
                 input_schema: report.schema(),
                 cache_control: None,
+                strict: None,
             },
         )]);
         Ok((report, req))

--- a/src/masks.rs
+++ b/src/masks.rs
@@ -439,7 +439,7 @@ impl StringArrayMask {
             } else if let serde_json::Value::Array(a) = value {
                 let mut all = vec![];
                 for v in a {
-                    all.extend(extract_strings(v, depth - 1)?.into_iter());
+                    all.extend(extract_strings(v, depth - 1)?);
                 }
                 Some(all)
             } else {

--- a/src/policy_type.rs
+++ b/src/policy_type.rs
@@ -1,7 +1,8 @@
 use claudius::{
     Anthropic, ContentBlock, JsonSchema, KnownModel, MessageCreateParams, MessageParam,
-    MessageRole, Model, ThinkingConfig,
+    MessageRole, Model, OutputFormat,
 };
+use uuid::Uuid;
 
 use crate::{parser, Field, ParseError, Policy};
 
@@ -67,52 +68,92 @@ impl PolicyType {
         injection: &str,
     ) -> Result<Policy, claudius::Error> {
         let mut schema = serde_json::json! {{}};
-        let mut properties = serde_json::json! {{}};
+        let mut action_masks = Vec::new();
         for field in self.fields.iter() {
-            let (name, schema) = match field {
+            let field_mask = Uuid::new_v4().to_string();
+            let (name, schema, enum_values) = match field {
                 Field::Bool {
                     name,
                     default: _,
                     on_conflict: _,
-                } => (name.clone(), bool::json_schema()),
+                } => (name.clone(), bool::json_schema(), Vec::new()),
                 Field::Number {
                     name,
                     default: _,
                     on_conflict: _,
-                } => (name.clone(), f64::json_schema()),
+                } => (name.clone(), f64::json_schema(), Vec::new()),
                 Field::String {
                     name,
                     default: _,
                     on_conflict: _,
-                } => (name.clone(), String::json_schema()),
+                } => (name.clone(), String::json_schema(), Vec::new()),
                 Field::StringEnum {
                     name,
                     values,
                     default: _,
                     on_conflict: _,
                 } => {
+                    let enum_values = values
+                        .iter()
+                        .map(|value| (value.clone(), Uuid::new_v4().to_string()))
+                        .collect::<Vec<_>>();
                     let mut schema = String::json_schema();
-                    schema["enum"] = values.clone().into();
-                    (name.clone(), schema)
+                    schema["enum"] = enum_values
+                        .iter()
+                        .map(|(_, mask)| mask.clone())
+                        .collect::<Vec<_>>()
+                        .into();
+                    (name.clone(), schema, enum_values)
                 }
-                Field::StringArray { name } => (name.clone(), Vec::<String>::json_schema()),
+                Field::StringArray { name } => {
+                    (name.clone(), Vec::<String>::json_schema(), Vec::new())
+                }
             };
-            properties[name] = schema;
+            action_masks.push(SemanticActionMask {
+                name,
+                mask: field_mask,
+                enum_values,
+                schema,
+            });
         }
-        schema["required"] = serde_json::json! {[]};
+        let mut masked_injection = semantic_action_clause(injection).to_string();
+        for action_mask in &action_masks {
+            masked_injection =
+                replace_token(&masked_injection, &action_mask.name, &action_mask.mask);
+            if let Some(singular) = action_mask.name.strip_suffix('s') {
+                masked_injection = replace_token(&masked_injection, singular, &action_mask.mask);
+            }
+            for (value, mask) in &action_mask.enum_values {
+                masked_injection =
+                    masked_injection.replace(&format!("{value:?}"), &format!("{mask:?}"));
+            }
+        }
+        let mut properties = serde_json::json! {{}};
+        let mut required = Vec::new();
+        for action_mask in &action_masks {
+            if masked_injection.contains(&action_mask.mask) {
+                properties[&action_mask.mask] = action_mask.schema.clone();
+                required.push(action_mask.mask.clone());
+            }
+        }
+        schema["required"] = required.into();
         schema["type"] = "object".into();
         schema["properties"] = properties;
+        schema["additionalProperties"] = false.into();
         let system = include_str!("../prompts/generate-semantic-injection.md").to_string();
         let req = MessageCreateParams {
             max_tokens: 2048,
-            model: Model::Known(KnownModel::ClaudeSonnet40),
+            model: Model::Known(KnownModel::ClaudeOpus48),
+            cache_control: None,
             messages: vec![MessageParam::new_with_string(
-                format!("<ask>{injection}</ask>"),
+                format!("<ask>{masked_injection}</ask>"),
                 MessageRole::User,
             )],
             system: Some(system.into()),
-            thinking: Some(ThinkingConfig::enabled(1024)),
+            thinking: None,
             metadata: None,
+            output_config: None,
+            output_format: Some(OutputFormat::json_schema(schema)),
             stop_sequences: None,
             temperature: None,
             tool_choice: None,
@@ -120,7 +161,14 @@ impl PolicyType {
             top_k: None,
             top_p: None,
             stream: false,
+            betas: None,
         };
+        if std::env::var_os("POLICYAI_LOG_SEMANTIC_REQUEST").is_some() {
+            eprintln!(
+                "semantic injection request:\n{}",
+                serde_json::to_string_pretty(&req)?
+            );
+        }
         let resp = client.send(req).await?;
         let prompt = injection.to_string();
         let raw_response = resp
@@ -152,12 +200,143 @@ impl PolicyType {
             raw_response.trim()
         };
 
-        let action = serde_json::from_str(json_content)?;
+        let mut action = serde_json::from_str(json_content)?;
+        unmask_semantic_action(&action_masks, &mut action);
+        self.sanitize_semantic_action(&mut action);
         Ok(Policy {
             r#type: self.clone(),
             prompt,
             action,
         })
+    }
+
+    fn sanitize_semantic_action(&self, action: &mut serde_json::Value) {
+        let serde_json::Value::Object(action) = action else {
+            return;
+        };
+        action.retain(|name, value| {
+            let Some(field) = self.fields.iter().find(|field| field.name() == name) else {
+                return false;
+            };
+            coerce_action_value(field, value)
+        });
+    }
+}
+
+struct SemanticActionMask {
+    name: String,
+    mask: String,
+    enum_values: Vec<(String, String)>,
+    schema: serde_json::Value,
+}
+
+fn unmask_semantic_action(masks: &[SemanticActionMask], action: &mut serde_json::Value) {
+    let serde_json::Value::Object(object) = action else {
+        return;
+    };
+    let mut unmasked = serde_json::Map::new();
+    for mask in masks {
+        let Some(mut value) = object.remove(&mask.mask) else {
+            continue;
+        };
+        if let Some(enum_value) = value.as_str().and_then(|value_string| {
+            mask.enum_values
+                .iter()
+                .find(|(_, enum_mask)| enum_mask == value_string)
+                .map(|(enum_value, _)| enum_value)
+        }) {
+            value = serde_json::Value::String(enum_value.clone());
+        }
+        unmasked.insert(mask.name.clone(), value);
+    }
+    *action = serde_json::Value::Object(unmasked);
+}
+
+fn semantic_action_clause(injection: &str) -> &str {
+    let trimmed = injection.trim();
+    if let Some((_, action)) = trimmed.split_once(':') {
+        return action.trim();
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("if ") || lower.starts_with("when ") {
+        if let Some(index) = trimmed.find(',') {
+            return trimmed[index + 1..].trim();
+        }
+    }
+    trimmed
+}
+
+fn replace_token(input: &str, token: &str, replacement: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut token_start = None;
+
+    for (index, ch) in input.char_indices() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            token_start.get_or_insert(index);
+        } else {
+            if let Some(start) = token_start.take() {
+                push_replaced_token(input, start, index, token, replacement, &mut output);
+            }
+            output.push(ch);
+        }
+    }
+
+    if let Some(start) = token_start {
+        push_replaced_token(input, start, input.len(), token, replacement, &mut output);
+    }
+
+    output
+}
+
+fn push_replaced_token(
+    input: &str,
+    start: usize,
+    end: usize,
+    token: &str,
+    replacement: &str,
+    output: &mut String,
+) {
+    let found = &input[start..end];
+    if found.eq_ignore_ascii_case(token) {
+        output.push_str(replacement);
+    } else {
+        output.push_str(found);
+    }
+}
+
+fn coerce_action_value(field: &Field, value: &mut serde_json::Value) -> bool {
+    match field {
+        Field::Bool { .. } => match value {
+            serde_json::Value::Bool(_) => true,
+            serde_json::Value::String(s) if s == "true" => {
+                *value = serde_json::Value::Bool(true);
+                true
+            }
+            serde_json::Value::String(s) if s == "false" => {
+                *value = serde_json::Value::Bool(false);
+                true
+            }
+            _ => false,
+        },
+        Field::Number { .. } => match value {
+            serde_json::Value::Number(_) => true,
+            serde_json::Value::String(s) => s
+                .parse::<f64>()
+                .ok()
+                .and_then(serde_json::Number::from_f64)
+                .map(|number| {
+                    *value = serde_json::Value::Number(number);
+                })
+                .is_some(),
+            _ => false,
+        },
+        Field::String { .. } => value.is_string(),
+        Field::StringEnum { values, .. } => value
+            .as_str()
+            .is_some_and(|value| values.iter().any(|allowed| allowed == value)),
+        Field::StringArray { .. } => value
+            .as_array()
+            .is_some_and(|values| values.iter().all(serde_json::Value::is_string)),
     }
 }
 
@@ -431,6 +610,68 @@ mod tests {
         assert!(debug_str.contains("PolicyType"));
         assert!(debug_str.contains("DebugTest"));
         assert!(debug_str.contains("fields"));
+    }
+
+    #[test]
+    fn sanitize_semantic_action_drops_unknown_fields() {
+        let policy_type = create_test_policy_type();
+        let mut action = serde_json::json!({
+            "active": true,
+            "priority": "high",
+            "extra": "ignored",
+        });
+
+        policy_type.sanitize_semantic_action(&mut action);
+
+        assert_eq!(
+            serde_json::json!({
+                "active": true,
+                "priority": "high",
+            }),
+            action
+        );
+    }
+
+    #[test]
+    fn sanitize_semantic_action_coerces_simple_values() {
+        let policy_type = create_test_policy_type();
+        let mut action = serde_json::json!({
+            "active": "true",
+            "score": "42.5",
+            "tags": ["example"],
+            "extra": "ignored",
+        });
+
+        policy_type.sanitize_semantic_action(&mut action);
+
+        assert_eq!(
+            serde_json::json!({
+                "active": true,
+                "score": 42.5,
+                "tags": ["example"],
+            }),
+            action
+        );
+    }
+
+    #[test]
+    fn semantic_action_clause_removes_condition() {
+        assert_eq!(
+            "Set \"priority\" to \"low\" and \"unread\" to true.",
+            semantic_action_clause(
+                "When the email is about AI:  Set \"priority\" to \"low\" and \"unread\" to true."
+            )
+        );
+        assert_eq!(
+            "set \"category\" to \"distributed systems\".",
+            semantic_action_clause(
+                "If the user talks about Paxos, set \"category\" to \"distributed systems\"."
+            )
+        );
+        assert_eq!(
+            "Assign weight to the email.",
+            semantic_action_clause("Assign weight to the email.")
+        );
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -186,8 +186,8 @@ impl Report {
             if *existing != serde_json::Value::Bool(default) {
                 self.errors.push(PolicyError::DefaultConflict {
                     field: field.to_string(),
-                    existing: existing.clone(),
-                    new: serde_json::Value::Bool(default),
+                    existing: Box::new(existing.clone()),
+                    new: Box::new(serde_json::Value::Bool(default)),
                     suggestion: "Ensure all policies use the same default value for this field"
                         .to_string(),
                 });
@@ -304,8 +304,8 @@ impl Report {
             if *existing != serde_json::Value::Number(default.clone()) {
                 self.errors.push(PolicyError::DefaultConflict {
                     field: field.to_string(),
-                    existing: existing.clone(),
-                    new: serde_json::Value::Number(default),
+                    existing: Box::new(existing.clone()),
+                    new: Box::new(serde_json::Value::Number(default)),
                     suggestion: "Ensure all policies use the same default value for this field"
                         .to_string(),
                 });
@@ -425,8 +425,8 @@ impl Report {
             if *existing != serde_json::Value::String(default.clone()) {
                 self.errors.push(PolicyError::DefaultConflict {
                     field: field.to_string(),
-                    existing: existing.clone(),
-                    new: serde_json::Value::String(default),
+                    existing: Box::new(existing.clone()),
+                    new: Box::new(serde_json::Value::String(default)),
                     suggestion: "Ensure all policies use the same default value for this field"
                         .to_string(),
                 });


### PR DESCRIPTION
Rework semantic injection generation to prevent the LLM from
leaking field names and enum values into the output. Replace field
names with UUID masks before sending the prompt, then unmask the
response. Strip conditional clauses from injection text so only the
action portion reaches the model. Use OutputFormat::json_schema
instead of tool-based extraction for more reliable structured output.

Add sanitization that drops unknown fields and coerces values to
their declared types (e.g. "true" -> true for bool fields). Improve
the generation prompt with clearer instructions and examples.

Update all dependencies to latest versions, including claudius
0.31.0 which introduces new MessageCreateParams fields (cache_control,
output_config, output_format, betas, strict). Box large serde_json
Value variants in error enums to satisfy clippy::large_enum_variant.

Co-authored-by: AI
