### PR TITLE
feat: make model configurable across the API surface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ shvar = "0.10.0"
 tokio = { version = "1.52.3", features = ["rt", "macros"] }
 utf8path = "0.11.0"
 uuid = { version = "1.18.1", features = ["v4"] }
+
+[dev-dependencies]
+biometrics_prometheus = "0.12"

--- a/README.md
+++ b/README.md
@@ -80,21 +80,24 @@ A semantic injection is a natural language instruction that generates structured
 let policy1 = policy_type
     .with_semantic_injection(
         &client,
-        "If the email is about football, mark \"unread\" false with low \"priority\""
+        "If the email is about football, mark \"unread\" false with low \"priority\"",
+        DEFAULT_MODEL
     )
     .await?;
 
 let policy2 = policy_type
     .with_semantic_injection(
         &client,
-        "If the email is from mom@example.org, set high \"priority\" and add Family \"label\""
+        "If the email is from mom@example.org, set high \"priority\" and add Family \"label\"",
+        DEFAULT_MODEL
     )
     .await?;
 
 let policy3 = policy_type
     .with_semantic_injection(
         &client,
-        "If the email is about shopping, add Shopping \"label\""
+        "If the email is about shopping, add Shopping \"label\"",
+        DEFAULT_MODEL
     )
     .await?;
 ```
@@ -264,7 +267,8 @@ When adding policies to your vector database, store both the semantic injection 
 let policy = policy_type
     .with_semantic_injection(
         &client,
-        "If email from VIP, set high priority"
+        "If email from VIP, set high priority",
+        DEFAULT_MODEL
     )
     .await?;
 
@@ -324,7 +328,7 @@ policyai = "0.3"
 Basic usage:
 
 ```rust
-use policyai::{PolicyType, Field, OnConflict, Manager};
+use policyai::{PolicyType, Field, OnConflict, Manager, DEFAULT_MODEL};
 use claudius::Anthropic;
 
 #[tokio::main]
@@ -340,7 +344,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a policy from natural language
     let policy = policy_type
-        .with_semantic_injection(&client, "Set high priority for urgent messages")
+        .with_semantic_injection(&client, "Set high priority for urgent messages", DEFAULT_MODEL)
         .await?;
 
     // Apply it

--- a/examples/generate-decidables.rs
+++ b/examples/generate-decidables.rs
@@ -2,7 +2,7 @@ use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader};
 
 use arrrg::CommandLine;
-use claudius::Anthropic;
+use claudius::{Anthropic, Model};
 use rand::prelude::*;
 
 #[derive(Clone, Default, Debug, Eq, PartialEq, arrrg_derive::CommandLine)]
@@ -19,6 +19,8 @@ struct Options {
         "The number of total verifications to perform for each policy."
     )]
     total: usize,
+    #[arrrg(optional, "Anthropic model to use for verification.")]
+    model: Option<String>,
 }
 
 #[tokio::main]
@@ -30,6 +32,11 @@ async fn main() -> Result<(), std::io::Error> {
         eprintln!("expected SEMANTIC-INJECTIONS");
         std::process::exit(13);
     }
+    let model = options
+        .model
+        .as_deref()
+        .map(|model| model.parse::<Model>().unwrap())
+        .unwrap_or(policyai::DEFAULT_MODEL);
     let client = Anthropic::new(None)
         .expect("could not connect to claude")
         .with_max_retries(10)
@@ -56,6 +63,7 @@ async fn main() -> Result<(), std::io::Error> {
                 policy_fragment,
                 options.success,
                 options.total,
+                model.clone(),
             )
             .await
             .unwrap()

--- a/examples/generate-semantic-injections.rs
+++ b/examples/generate-semantic-injections.rs
@@ -2,9 +2,7 @@ use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader};
 
 use arrrg::CommandLine;
-use claudius::{
-    Anthropic, CacheControlEphemeral, KnownModel, Model, SystemPrompt, TextBlock, ThinkingConfig,
-};
+use claudius::{Anthropic, CacheControlEphemeral, Model, SystemPrompt, TextBlock, ThinkingConfig};
 use rand::prelude::*;
 
 #[derive(Clone, Default, Debug, Eq, PartialEq, arrrg_derive::CommandLine)]
@@ -23,6 +21,8 @@ struct Options {
         "The number of total verifications to perform for each policy."
     )]
     total: usize,
+    #[arrrg(optional, "Anthropic model to use for generation and verification.")]
+    model: Option<String>,
 }
 
 #[tokio::main]
@@ -33,6 +33,11 @@ async fn main() -> Result<(), claudius::Error> {
         eprintln!("expected TEXTS");
         std::process::exit(13);
     }
+    let model = options
+        .model
+        .as_deref()
+        .map(|model| model.parse::<Model>().unwrap())
+        .unwrap_or(policyai::DEFAULT_MODEL);
     let texts_file = BufReader::new(OpenOptions::new().read(true).open(&free[0]).unwrap());
     let mut texts = vec![];
     for line in texts_file.lines() {
@@ -82,7 +87,7 @@ Text:
             let req = claudius::MessageCreateParams {
                 max_tokens: 2048,
                 messages: vec![prompt.into()],
-                model: Model::Known(KnownModel::ClaudeOpus48),
+                model: model.clone(),
                 cache_control: None,
                 metadata: None,
                 output_config: None,
@@ -119,6 +124,7 @@ Text:
                 &injection,
                 options.success,
                 options.total,
+                model.clone(),
             )
             .await?
             {

--- a/src/bin/policyai-evaluate-policies.rs
+++ b/src/bin/policyai-evaluate-policies.rs
@@ -3,12 +3,12 @@ use std::io::{BufRead, BufReader};
 use std::time::Instant;
 
 use claudius::{
-    push_or_merge_message, Anthropic, ContentBlock, JsonSchema, KnownModel, MessageCreateParams,
-    MessageParam, MessageRole, Metadata, Model, SystemPrompt, TextBlock, ToolChoice,
+    push_or_merge_message, Anthropic, ContentBlock, JsonSchema, MessageCreateParams, MessageParam,
+    MessageRole, Metadata, Model, SystemPrompt, TextBlock, ToolChoice,
 };
 
 use policyai::data::{EvaluationReport, Metrics, TestDataPoint};
-use policyai::{ApplyError, Field, Manager, Policy, Report, Usage};
+use policyai::{ApplyError, Field, Manager, Policy, Report, Usage, DEFAULT_MODEL};
 
 pub async fn naive_apply(
     client: &Anthropic,
@@ -243,8 +243,9 @@ fn calculate_field_metrics(
 
 #[tokio::main]
 async fn main() {
+    let (model, files) = parse_args();
     let client = Anthropic::new(None).unwrap();
-    for file in std::env::args().skip(1) {
+    for file in files {
         let file = OpenOptions::new()
             .read(true)
             .open(file)
@@ -274,7 +275,7 @@ async fn main() {
                 &point.policies,
                 &MessageCreateParams {
                     max_tokens: 4096,
-                    model: Model::Known(KnownModel::ClaudeOpus48),
+                    model: model.clone(),
                     ..Default::default()
                 },
                 &point.text,
@@ -309,7 +310,7 @@ async fn main() {
                     &client,
                     MessageCreateParams {
                         max_tokens: 4096,
-                        model: Model::Known(KnownModel::ClaudeOpus48),
+                        model: model.clone(),
                         ..Default::default()
                     },
                     &point.text,
@@ -348,6 +349,26 @@ async fn main() {
             println!("{}", serde_json::to_string(&report).unwrap());
         }
     }
+}
+
+fn parse_args() -> (Model, Vec<String>) {
+    let mut model = DEFAULT_MODEL;
+    let mut files = Vec::new();
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--model" {
+            let Some(value) = args.next() else {
+                eprintln!("--model requires a value");
+                std::process::exit(2);
+            };
+            model = value.parse::<Model>().unwrap();
+        } else if let Some(value) = arg.strip_prefix("--model=") {
+            model = value.parse::<Model>().unwrap();
+        } else {
+            files.push(arg);
+        }
+    }
+    (model, files)
 }
 
 #[cfg(test)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,9 +5,9 @@
 //! and structures for evaluation metrics and test data points.
 
 use claudius::{
-    Anthropic, CacheControlEphemeral, ContentBlock, Effort, KnownModel, MessageCreateParams,
-    MessageParam, MessageParamContent, MessageRole, Model, OutputConfig, StopReason, SystemPrompt,
-    TextBlock, ThinkingConfig,
+    Anthropic, CacheControlEphemeral, ContentBlock, Effort, MessageCreateParams, MessageParam,
+    MessageParamContent, MessageRole, Model, OutputConfig, StopReason, SystemPrompt, TextBlock,
+    ThinkingConfig,
 };
 
 use crate::{Policy, Report, Usage};
@@ -52,6 +52,7 @@ pub struct SemanticInjection {
 /// * `semantic_injection` - The policy's semantic injection rule
 /// * `k` - Minimum number of successes required
 /// * `n` - Maximum number of attempts to make
+/// * `model` - The model to use for policy applicability checks
 ///
 /// # Returns
 ///
@@ -66,7 +67,7 @@ pub struct SemanticInjection {
 ///
 /// ```no_run
 /// use claudius::Anthropic;
-/// use policyai::data::policy_applies;
+/// use policyai::{data::policy_applies, DEFAULT_MODEL};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Anthropic::new(None)?;
@@ -75,7 +76,8 @@ pub struct SemanticInjection {
 ///     "This is urgent!",
 ///     "If text indicates urgency, mark as high priority",
 ///     3,  // Need 3 successes
-///     5   // Out of 5 attempts
+///     5,  // Out of 5 attempts
+///     DEFAULT_MODEL
 /// ).await?;
 /// # Ok(())
 /// # }
@@ -86,8 +88,9 @@ pub async fn policy_applies(
     semantic_injection: &str,
     k: usize,
     n: usize,
+    model: Model,
 ) -> Result<bool, claudius::Error> {
-    Ok(apply_policy_fractional(client, text, semantic_injection, k, n).await? >= k)
+    Ok(apply_policy_fractional(client, text, semantic_injection, k, n, model).await? >= k)
 }
 
 /// Determine if a policy does NOT apply to given text with statistical confidence.
@@ -103,6 +106,7 @@ pub async fn policy_applies(
 /// * `semantic_injection` - The policy's semantic injection rule
 /// * `k` - Minimum number of successes that would indicate the policy applies
 /// * `n` - Maximum number of attempts to make
+/// * `model` - The model to use for policy applicability checks
 ///
 /// # Returns
 ///
@@ -117,7 +121,7 @@ pub async fn policy_applies(
 ///
 /// ```no_run
 /// use claudius::Anthropic;
-/// use policyai::data::policy_does_not_apply;
+/// use policyai::{data::policy_does_not_apply, DEFAULT_MODEL};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Anthropic::new(None)?;
@@ -126,7 +130,8 @@ pub async fn policy_applies(
 ///     "Regular email content",
 ///     "If text indicates urgency, mark as high priority",
 ///     3,  // Would need 3 successes to apply
-///     5   // Out of 5 attempts
+///     5,  // Out of 5 attempts
+///     DEFAULT_MODEL
 /// ).await?;
 /// # Ok(())
 /// # }
@@ -137,9 +142,10 @@ pub async fn policy_does_not_apply(
     semantic_injection: &str,
     k: usize,
     n: usize,
+    model: Model,
 ) -> Result<bool, claudius::Error> {
     Ok(
-        apply_policy_fractional(client, text, semantic_injection, k, n).await?
+        apply_policy_fractional(client, text, semantic_injection, k, n, model).await?
             <= n.saturating_sub(k),
     )
 }
@@ -150,6 +156,7 @@ async fn apply_policy_fractional(
     semantic_injection: &str,
     k: usize,
     n: usize,
+    model: Model,
 ) -> Result<usize, claudius::Error> {
     let mut success = 0;
     let mut total = 0;
@@ -173,7 +180,7 @@ Output just this one-word answer
         .to_string();
         let req = MessageCreateParams {
             max_tokens: 1030,
-            model: Model::Known(KnownModel::ClaudeOpus48),
+            model: model.clone(),
             cache_control: None,
             system: Some(SystemPrompt::from_blocks(vec![TextBlock {
                 text: system.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,10 @@ pub use report::{FieldStats, Report};
 pub use report_builder::ReportBuilder;
 pub use usage::Usage;
 
+/// The default model PolicyAI uses when a caller does not provide one.
+pub const DEFAULT_MODEL: claudius::Model =
+    claudius::Model::Known(claudius::KnownModel::ClaudeSonnet45);
+
 //////////////////////////////////////////////// t64 ///////////////////////////////////////////////
 
 /// A totally-ordered 64-bit floating point number.
@@ -147,7 +151,7 @@ pub(crate) fn number_less_than(lhs: &serde_json::Number, rhs: &serde_json::Numbe
 
 #[cfg(test)]
 mod tests {
-    use claudius::{Anthropic, KnownModel, MessageCreateParams, Model};
+    use claudius::{Anthropic, MessageCreateParams};
 
     use super::*;
 
@@ -320,6 +324,7 @@ mod tests {
             .with_semantic_injection(
                 &client,
                 "If the user talks about Paxos, set \"category\" to \"distributed systems\".",
+                DEFAULT_MODEL,
             )
             .await
             .unwrap();
@@ -343,7 +348,7 @@ mod tests {
             }],
         };
         let policy = policy
-            .with_semantic_injection(&client, "Assign weight to the email.")
+            .with_semantic_injection(&client, "Assign weight to the email.", DEFAULT_MODEL)
             .await
             .unwrap();
         assert!(matches!(
@@ -393,6 +398,7 @@ mod tests {
             .with_semantic_injection(
                 &client,
                 "When the email is about AI:  Set \"priority\" to \"low\" and \"unread\" to true.",
+                DEFAULT_MODEL,
             )
             .await
             .unwrap();
@@ -407,7 +413,7 @@ mod tests {
                 &Anthropic::new(None).unwrap(),
                 MessageCreateParams {
                     max_tokens: 2048,
-                    model: Model::Known(KnownModel::ClaudeOpus48),
+                    model: DEFAULT_MODEL,
                     ..Default::default()
                 },
                 r#"From: robert@example.org

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -40,8 +40,8 @@ impl InferenceConfig {
 /// ```no_run
 /// use policyai::Manager;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// # use claudius::{Anthropic, MessageCreateParams, KnownModel, Model, MessageParam, MessageRole};
-/// # use policyai::{PolicyType, Policy, Usage};
+/// # use claudius::{Anthropic, MessageCreateParams, MessageParam, MessageRole};
+/// # use policyai::{PolicyType, Policy, Usage, DEFAULT_MODEL};
 ///
 /// let mut manager = Manager::default();
 /// # let client = Anthropic::new(None)?;
@@ -55,7 +55,7 @@ impl InferenceConfig {
 ///
 /// # let template = MessageCreateParams {
 /// #     max_tokens: 1024,
-/// #     model: Model::Known(KnownModel::ClaudeOpus48),
+/// #     model: DEFAULT_MODEL,
 /// #     messages: vec![],
 /// #     ..Default::default()
 /// # };

--- a/src/policy_type.rs
+++ b/src/policy_type.rs
@@ -1,6 +1,6 @@
 use claudius::{
-    Anthropic, ContentBlock, JsonSchema, KnownModel, MessageCreateParams, MessageParam,
-    MessageRole, Model, OutputFormat,
+    Anthropic, ContentBlock, JsonSchema, MessageCreateParams, MessageParam, MessageRole, Model,
+    OutputFormat,
 };
 use uuid::Uuid;
 
@@ -61,11 +61,13 @@ impl PolicyType {
     /// Create a new Policy by applying a semantic injection to this PolicyType.
     ///
     /// The semantic injection is a natural language description that gets converted
-    /// into structured actions that conform to this PolicyType's schema.
+    /// into structured actions that conform to this PolicyType's schema using the
+    /// provided model.
     pub async fn with_semantic_injection(
         &self,
         client: &Anthropic,
         injection: &str,
+        model: Model,
     ) -> Result<Policy, claudius::Error> {
         let mut schema = serde_json::json! {{}};
         let mut action_masks = Vec::new();
@@ -143,7 +145,7 @@ impl PolicyType {
         let system = include_str!("../prompts/generate-semantic-injection.md").to_string();
         let req = MessageCreateParams {
             max_tokens: 2048,
-            model: Model::Known(KnownModel::ClaudeOpus48),
+            model,
             cache_control: None,
             messages: vec![MessageParam::new_with_string(
                 format!("<ask>{masked_injection}</ask>"),


### PR DESCRIPTION
Add a DEFAULT_MODEL constant (Claude Sonnet 4.5) and thread a Model
parameter through all functions that previously hardcoded a model:

- Add DEFAULT_MODEL to lib.rs as the single source of truth
- Add model parameter to PolicyType::with_semantic_injection
- Add model parameter to policy_applies, policy_does_not_apply, and
  apply_policy_fractional in data.rs
- Add --model CLI flag to generate-decidables, generate-semantic-
  injections, and policyai-evaluate-policies
- Remove unused KnownModel imports where no longer needed
- Update README examples to pass DEFAULT_MODEL

Co-authored-by: AI
