### PR TITLE
refactor: harden policy composition and conflict resolution

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,8 +2,7 @@ name: ci
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:
 env:
   CARGO_TERM_COLOR: always
 jobs:
@@ -25,3 +24,4 @@ jobs:
       run: cargo test
       env:
         CLAUDIUS_API_KEY: ${{ secrets.CLAUDIUS_API_KEY }}
+        POLICYAI_LIVE_TESTS: "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,13 @@ arrrg = "0.10.0"
 arrrg_derive = "0.10.0"
 claudius = "0.31.0"
 getopts = "0.2.24"
-guacamole = "0.16.0"
-rand = "0.10.1"
-reqwest = "0.13.4"
-rustyline = { version = "18.0.0", features = ["derive"] }
 serde = "1.0.228"
 serde_json = { version = "1.0.150", features = ["preserve_order"] }
-shvar = "0.10.0"
 tokio = { version = "1.52.3", features = ["rt", "macros"] }
-utf8path = "0.11.0"
 uuid = { version = "1.18.1", features = ["v4"] }
 
 [dev-dependencies]
+biometrics = "0.14"
 biometrics_prometheus = "0.12"
+guacamole = "0.16.0"
+rand = "0.10.1"

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ let policy3 = policy_type
 
 ```rust
 let mut manager = Manager::default();
-manager.add(policy1);
-manager.add(policy2);
-manager.add(policy3);
+manager.add(policy1)?;
+manager.add(policy2)?;
+manager.add(policy3)?;
 
 let report = manager.apply(
     &client,
@@ -216,9 +216,11 @@ PolicyAI is **not** the right tool when:
 
 For production agents with large policy sets, you don't want to apply every policy to every input. Use **vector retrieval** to select relevant policies dynamically:
 
-### Pattern: PolicyAI + Chroma
+### Pattern: PolicyAI + Vector Retrieval
 
-(Example is illustrative, but likely needs work to work because Claude hallucinated some of this)
+The exact storage API depends on your vector database. The durable pattern is to
+embed the policy's semantic injection, store the serialized `Policy`, retrieve a
+small top-k set for each input, and compose only those policies.
 
 ```rust
 use chromadb::{ChromaClient, Collection};
@@ -229,7 +231,7 @@ async fn process_with_retrieval(
     chroma: &Collection,
     input: &str,
 ) -> Result<Report, Box<dyn std::error::Error>> {
-    // 1. Retrieve relevant policies from vector database
+    // 1. Retrieve relevant policies from your vector database
     let results = chroma.query(
         vec![input.to_string()],
         5,  // top 5 most relevant policies
@@ -250,7 +252,7 @@ async fn process_with_retrieval(
     // 3. Apply only relevant policies
     let mut manager = Manager::default();
     for policy in policies {
-        manager.add(policy);
+        manager.add(policy)?;
     }
 
     let report = manager.apply(client, template, input, None).await?;
@@ -322,7 +324,7 @@ Add PolicyAI to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-policyai = "0.3"
+policyai = "0.4"
 ```
 
 Basic usage:
@@ -349,7 +351,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Apply it
     let mut manager = Manager::default();
-    manager.add(policy);
+    manager.add(policy)?;
 
     let report = manager.apply(
         &client,
@@ -371,6 +373,11 @@ PolicyAI includes tools for testing and debugging:
 - `policyai-regression-report`: Generate reports on policy behavior
 - `policyai-extract-regressions`: Extract failing cases for analysis
 - `policyai-regressions-to-examples`: Convert regressions to test examples
+
+## Testing
+
+Run deterministic tests with `cargo test`. Live Anthropic-backed tests are
+skipped unless `POLICYAI_LIVE_TESTS=1` is set alongside `CLAUDIUS_API_KEY`.
 
 ## Implementation Note
 

--- a/prompts/generate-semantic-injection.md
+++ b/prompts/generate-semantic-injection.md
@@ -2,7 +2,13 @@ Your task is to assume that the following message's conditional ask is true.
 
 Assume it is true and generate a sample response. Your sample response must be a JSON object with the minimal number of fields necessary to satisfy the ask.
 
-Only output fields the user explicitly requests. Do not include a field just because it exists in the schema, has a default value, or is semantically related to the ask.
+Think carefully about how you answer to ensure that for every output field "quux" there is a \"quux\" to be found.
+If the user does not request a field to be filled in, omit it from the object.
+Do not infer output fields from the condition that makes the policy apply.  Text such as "when the email is
+about AI" describes when the policy applies; it does not mean to output a category field unless the user asks
+you to set the category field.
+Include every field the user explicitly asks to set, mark, or add even if the value equals that field's default.
+Never include empty arrays, null fields, or fields that are merely possible according to the schema.
 
 Conditional text describes when the policy applies; it is not output data. If the input says "When ...:" or "If ...," do not create JSON fields from the condition. Create JSON fields only from the requested action.
 

--- a/src/bin/policyai-evaluate-policies.rs
+++ b/src/bin/policyai-evaluate-policies.rs
@@ -119,10 +119,19 @@ pub async fn naive_apply(
     }
 
     if resp.content.len() != 1 {
-        todo!();
+        return Err(ApplyError::invalid_response(
+            format!(
+                "Expected exactly 1 content block, got {}",
+                resp.content.len()
+            ),
+            "The baseline evaluator expects the model to call the output_json tool once",
+        ));
     }
     let ContentBlock::ToolUse(t) = &resp.content[0] else {
-        todo!();
+        return Err(ApplyError::invalid_response(
+            "Expected ToolUse content block",
+            "The baseline evaluator expects the model to use the output_json tool",
+        ));
     };
     Ok(t.input.clone())
 }
@@ -261,8 +270,12 @@ async fn main() {
                 }
             };
             let mut manager = Manager::default();
+            let mut manager_error = None;
             for policy in point.policies.iter() {
-                manager.add(policy.clone());
+                if let Err(err) = manager.add(policy.clone()) {
+                    manager_error = Some(err);
+                    break;
+                }
             }
             let expected = build_expected_with_defaults(&point.policies, point.expected.as_ref());
             let mut metrics = Metrics::default();
@@ -305,24 +318,30 @@ async fn main() {
             // Run policyai
             let mut policyai_usage = Some(Usage::new());
             let start = Instant::now();
-            let report = match manager
-                .apply(
-                    &client,
-                    MessageCreateParams {
-                        max_tokens: 4096,
-                        model: model.clone(),
-                        ..Default::default()
-                    },
-                    &point.text,
-                    policyai_usage.as_mut(),
-                )
-                .await
-            {
-                Ok(returned) => returned,
-                Err(err) => {
-                    metrics.policyai_error = Some(format!("{err:?}"));
-                    metrics.policyai_apply_duration_ms = start.elapsed().as_millis() as u32;
-                    Report::default()
+            let report = if let Some(err) = manager_error {
+                metrics.policyai_error = Some(format!("{err:?}"));
+                metrics.policyai_apply_duration_ms = start.elapsed().as_millis() as u32;
+                Report::default()
+            } else {
+                match manager
+                    .apply(
+                        &client,
+                        MessageCreateParams {
+                            max_tokens: 4096,
+                            model: model.clone(),
+                            ..Default::default()
+                        },
+                        &point.text,
+                        policyai_usage.as_mut(),
+                    )
+                    .await
+                {
+                    Ok(returned) => returned,
+                    Err(err) => {
+                        metrics.policyai_error = Some(format!("{err:?}"));
+                        metrics.policyai_apply_duration_ms = start.elapsed().as_millis() as u32;
+                        Report::default()
+                    }
                 }
             };
             metrics.policyai_apply_duration_ms = start.elapsed().as_millis() as u32;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,6 +68,13 @@ pub enum PolicyError {
         /// The actual type that was found.
         actual: String,
     },
+    /// A manager was asked to compose policies with different policy types.
+    PolicyTypeMismatch {
+        /// The policy type already managed.
+        expected: String,
+        /// The policy type supplied by the new policy.
+        found: String,
+    },
 }
 
 impl PolicyError {
@@ -176,6 +183,12 @@ impl std::fmt::Display for PolicyError {
                 actual,
             } => {
                 write!(f, "Type check failure at {file}:{line}: {message}\n  Expected: {expected}\n  Actual: {actual}\nSuggestion: Verify that your policy actions match the policy type definition")
+            }
+            PolicyError::PolicyTypeMismatch { expected, found } => {
+                write!(
+                    f,
+                    "Policy type mismatch:\n  Expected: {expected}\n  Found: {found}\nSuggestion: Only compose policies created from the same PolicyType"
+                )
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,14 @@ mod tests {
 
     use super::*;
 
+    fn live_anthropic_client() -> Option<Anthropic> {
+        if std::env::var_os("POLICYAI_LIVE_TESTS").is_none() {
+            eprintln!("skipping live Anthropic test; set POLICYAI_LIVE_TESTS=1 to run it");
+            return None;
+        }
+        Some(Anthropic::new(None).expect("could not create Anthropic client"))
+    }
+
     #[test]
     fn t64_equality() {
         assert_eq!(t64(1.0), t64(1.0));
@@ -285,7 +293,9 @@ mod tests {
 
     #[tokio::test]
     async fn with_semantic_injection() {
-        let client = Anthropic::new(None).unwrap();
+        let Some(client) = live_anthropic_client() else {
+            return;
+        };
         let policy = PolicyType {
             name: "policyai::EmailPolicy".to_string(),
             fields: vec![
@@ -338,7 +348,9 @@ mod tests {
 
     #[tokio::test]
     async fn numeric_semantic_injection() {
-        let client = Anthropic::new(None).unwrap();
+        let Some(client) = live_anthropic_client() else {
+            return;
+        };
         let policy = PolicyType {
             name: "policyai::EmailPolicy".to_string(),
             fields: vec![Field::Number {
@@ -359,7 +371,9 @@ mod tests {
 
     #[tokio::test]
     async fn apply_readme_policy() {
-        let client = Anthropic::new(None).unwrap();
+        let Some(client) = live_anthropic_client() else {
+            return;
+        };
         let policy = PolicyType {
             name: "policyai::EmailPolicy".to_string(),
             fields: vec![
@@ -407,10 +421,10 @@ mod tests {
             policy.action
         );
         let mut manager = Manager::default();
-        manager.add(policy);
+        manager.add(policy).unwrap();
         let report = manager
             .apply(
-                &Anthropic::new(None).unwrap(),
+                &client,
                 MessageCreateParams {
                     max_tokens: 2048,
                     model: DEFAULT_MODEL,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -51,7 +51,7 @@ impl InferenceConfig {
 /// #     prompt: "Test policy".to_string(),
 /// #     action: serde_json::json!({}),
 /// # };
-/// manager.add(policy);
+/// manager.add(policy)?;
 ///
 /// # let template = MessageCreateParams {
 /// #     max_tokens: 1024,
@@ -97,14 +97,22 @@ impl Manager {
 
     /// Add a policy to the manager.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the policy type doesn't match existing policies in the manager.
-    pub fn add(&mut self, policy: Policy) {
+    /// Returns [`PolicyError::PolicyTypeMismatch`] if the policy type does not
+    /// match the policies already in the manager.
+    #[allow(clippy::result_large_err)]
+    pub fn add(&mut self, policy: Policy) -> Result<(), crate::PolicyError> {
         if let Some(last) = self.policies.last() {
-            assert_eq!(last.r#type, policy.r#type);
+            if last.r#type != policy.r#type {
+                return Err(crate::PolicyError::PolicyTypeMismatch {
+                    expected: last.r#type.to_string(),
+                    found: policy.r#type.to_string(),
+                });
+            }
         }
         self.policies.push(policy);
+        Ok(())
     }
 
     /// Get the number of policies managed.
@@ -391,6 +399,7 @@ enum FeedbackTarget {
     Text,
 }
 
+#[allow(clippy::result_large_err)]
 fn extract_ir(
     content: &[ContentBlock],
     inference_config: InferenceConfig,
@@ -538,7 +547,7 @@ mod tests {
             serde_json::json!({"is_active": true}),
         );
 
-        manager.add(policy);
+        manager.add(policy).unwrap();
         assert!(!manager.is_empty());
         assert_eq!(manager.len(), 1);
     }
@@ -564,16 +573,15 @@ mod tests {
             serde_json::json!({"count": 42}),
         );
 
-        manager.add(policy1);
-        manager.add(policy2);
-        manager.add(policy3);
+        manager.add(policy1).unwrap();
+        manager.add(policy2).unwrap();
+        manager.add(policy3).unwrap();
 
         assert_eq!(manager.len(), 3);
     }
 
     #[test]
-    #[should_panic]
-    fn manager_add_policy_different_type_panics() {
+    fn manager_add_policy_different_type_returns_error() {
         let mut manager = Manager::default();
 
         let type1 = create_test_policy_type();
@@ -589,8 +597,9 @@ mod tests {
         let policy1 = create_test_policy(type1, "first", serde_json::json!({"is_active": true}));
         let policy2 = create_test_policy(type2, "second", serde_json::json!({"enabled": false}));
 
-        manager.add(policy1);
-        manager.add(policy2); // This should panic
+        manager.add(policy1).unwrap();
+        let err = manager.add(policy2).unwrap_err();
+        assert!(matches!(err, crate::PolicyError::PolicyTypeMismatch { .. }));
     }
 
     #[tokio::test]
@@ -682,8 +691,8 @@ mod tests {
             serde_json::json!({"message": "greeting"}),
         );
 
-        manager.add(policy1);
-        manager.add(policy2);
+        manager.add(policy1).unwrap();
+        manager.add(policy2).unwrap();
 
         let template = MessageCreateParams::default();
         let text = "urgent hello world";
@@ -692,7 +701,6 @@ mod tests {
         assert!(result.is_ok());
 
         let (report, req) = result.unwrap();
-        println!("Number of messages: {}", req.messages.len()); // Debug output
         assert!(!req.messages.is_empty()); // At least one message
         assert!(req.system.is_some());
         assert!(req.tools.is_some());

--- a/src/masks.rs
+++ b/src/masks.rs
@@ -485,6 +485,8 @@ pub struct StringEnumMask {
     pub mask: String,
     /// The specific enum value this mask represents
     pub value: Option<String>,
+    /// The declared enum values in increasing order.
+    pub values: Vec<String>,
     /// Default enum value when the field is not present
     pub default: Option<String>,
     /// Strategy for resolving conflicts when multiple policies set different values
@@ -500,6 +502,7 @@ impl StringEnumMask {
     /// * `name` - The original field name from the policy definition
     /// * `mask` - The masked field name unlikely to be in LLM training data
     /// * `value` - The specific enum value this mask represents
+    /// * `values` - The allowed enum values in increasing order
     /// * `default` - The default enum value when field is absent
     /// * `on_conflict` - Strategy for resolving conflicts between policies
     ///
@@ -512,6 +515,7 @@ impl StringEnumMask {
     ///     "status".to_string(),
     ///     "field_enum456".to_string(),
     ///     Some("active".to_string()),
+    ///     vec!["inactive".to_string(), "active".to_string()],
     ///     Some("inactive".to_string()),
     ///     OnConflict::LargestValue
     /// );
@@ -521,6 +525,7 @@ impl StringEnumMask {
         name: String,
         mask: String,
         value: Option<String>,
+        values: Vec<String>,
         default: Option<String>,
         on_conflict: OnConflict,
     ) -> Self {
@@ -529,6 +534,7 @@ impl StringEnumMask {
             name,
             mask,
             value,
+            values,
             default,
             on_conflict,
         }
@@ -550,7 +556,7 @@ impl StringEnumMask {
     /// ```
     /// # use policyai::{StringEnumMask, OnConflict, Report};
     /// # use claudius::MessageParam;
-    /// let mask = StringEnumMask::new(1, "priority".to_string(), "field_enum".to_string(), Some("high".to_string()), None, OnConflict::Default);
+    /// let mask = StringEnumMask::new(1, "priority".to_string(), "field_enum".to_string(), Some("high".to_string()), vec!["low".to_string(), "high".to_string()], None, OnConflict::Default);
     /// let ir = serde_json::json!({"field_enum": true});
     /// let mut report = Report::new(vec![], vec![], vec![], vec![], vec![], vec![], vec![]);
     /// mask.apply_to(&ir, &mut report);
@@ -564,6 +570,7 @@ impl StringEnumMask {
                             self.policy_index,
                             &self.name,
                             enum_value.clone(),
+                            &self.values,
                             self.on_conflict,
                         );
                     } else {

--- a/src/policy_type.rs
+++ b/src/policy_type.rs
@@ -1,6 +1,6 @@
 use claudius::{
     Anthropic, ContentBlock, JsonSchema, MessageCreateParams, MessageParam, MessageRole, Model,
-    OutputFormat,
+    ToolChoice,
 };
 use uuid::Uuid;
 
@@ -73,7 +73,7 @@ impl PolicyType {
         let mut action_masks = Vec::new();
         for field in self.fields.iter() {
             let field_mask = Uuid::new_v4().to_string();
-            let (name, schema, enum_values) = match field {
+            let (name, field_schema, enum_values) = match field {
                 Field::Bool {
                     name,
                     default: _,
@@ -115,7 +115,7 @@ impl PolicyType {
                 name,
                 mask: field_mask,
                 enum_values,
-                schema,
+                schema: field_schema,
             });
         }
         let mut masked_injection = semantic_action_clause(injection).to_string();
@@ -133,7 +133,7 @@ impl PolicyType {
         let mut properties = serde_json::json! {{}};
         let mut required = Vec::new();
         for action_mask in &action_masks {
-            if masked_injection.contains(&action_mask.mask) {
+            if self.fields.len() == 1 || masked_injection.contains(&action_mask.mask) {
                 properties[&action_mask.mask] = action_mask.schema.clone();
                 required.push(action_mask.mask.clone());
             }
@@ -155,11 +155,19 @@ impl PolicyType {
             thinking: None,
             metadata: None,
             output_config: None,
-            output_format: Some(OutputFormat::json_schema(schema)),
+            output_format: None,
             stop_sequences: None,
             temperature: None,
-            tool_choice: None,
-            tools: None,
+            tool_choice: Some(ToolChoice::tool("output_json")),
+            tools: Some(vec![claudius::ToolUnionParam::CustomTool(
+                claudius::ToolParam {
+                    name: "output_json".to_string(),
+                    description: Some("output JSON according to the requested policy type".into()),
+                    input_schema: schema,
+                    cache_control: None,
+                    strict: Some(true),
+                },
+            )]),
             top_k: None,
             top_p: None,
             stream: false,
@@ -173,6 +181,22 @@ impl PolicyType {
         }
         let resp = client.send(req).await?;
         let prompt = injection.to_string();
+        if let Some(tool) = resp.content.iter().find_map(|content| {
+            if let ContentBlock::ToolUse(tool) = content {
+                Some(tool)
+            } else {
+                None
+            }
+        }) {
+            let mut action = tool.input.clone();
+            unmask_semantic_action(&action_masks, &mut action);
+            return Ok(Policy {
+                r#type: self.clone(),
+                prompt,
+                action: self.sanitize_semantic_action(injection, action),
+            });
+        }
+
         let raw_response = resp
             .content
             .iter()
@@ -204,7 +228,7 @@ impl PolicyType {
 
         let mut action = serde_json::from_str(json_content)?;
         unmask_semantic_action(&action_masks, &mut action);
-        self.sanitize_semantic_action(&mut action);
+        let action = self.sanitize_semantic_action(injection, action);
         Ok(Policy {
             r#type: self.clone(),
             prompt,
@@ -212,16 +236,29 @@ impl PolicyType {
         })
     }
 
-    fn sanitize_semantic_action(&self, action: &mut serde_json::Value) {
-        let serde_json::Value::Object(action) = action else {
-            return;
+    fn sanitize_semantic_action(
+        &self,
+        injection: &str,
+        action: serde_json::Value,
+    ) -> serde_json::Value {
+        let serde_json::Value::Object(mut action) = action else {
+            return action;
         };
-        action.retain(|name, value| {
-            let Some(field) = self.fields.iter().find(|field| field.name() == name) else {
-                return false;
+        let mut sanitized = serde_json::Map::new();
+        let single_field = self.fields.len() == 1;
+        let action_clause = semantic_action_clause(injection);
+        for field in &self.fields {
+            let Some(mut value) = action.remove(field.name()) else {
+                continue;
             };
-            coerce_action_value(field, value)
-        });
+            if !single_field && !field_is_mentioned(action_clause, field.name()) {
+                continue;
+            }
+            if coerce_action_value(field, &mut value) {
+                sanitized.insert(field.name().to_string(), value);
+            }
+        }
+        serde_json::Value::Object(sanitized)
     }
 }
 
@@ -306,6 +343,27 @@ fn push_replaced_token(
     }
 }
 
+fn field_is_mentioned(input: &str, field_name: &str) -> bool {
+    contains_word_case_insensitive(input, field_name)
+        || field_name
+            .strip_suffix('s')
+            .is_some_and(|singular| contains_word_case_insensitive(input, singular))
+}
+
+fn contains_word_case_insensitive(input: &str, needle: &str) -> bool {
+    let input = input.to_lowercase();
+    let needle = needle.to_lowercase();
+    input.match_indices(&needle).any(|(index, _)| {
+        let before = input[..index].chars().next_back();
+        let after = input[index + needle.len()..].chars().next();
+        !before.is_some_and(is_identifier_char) && !after.is_some_and(is_identifier_char)
+    })
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
+}
+
 fn coerce_action_value(field: &Field, value: &mut serde_json::Value) -> bool {
     match field {
         Field::Bool { .. } => match value {
@@ -336,9 +394,9 @@ fn coerce_action_value(field: &Field, value: &mut serde_json::Value) -> bool {
         Field::StringEnum { values, .. } => value
             .as_str()
             .is_some_and(|value| values.iter().any(|allowed| allowed == value)),
-        Field::StringArray { .. } => value
-            .as_array()
-            .is_some_and(|values| values.iter().all(serde_json::Value::is_string)),
+        Field::StringArray { .. } => value.as_array().is_some_and(|values| {
+            !values.is_empty() && values.iter().all(serde_json::Value::is_string)
+        }),
     }
 }
 
@@ -387,6 +445,71 @@ mod tests {
                 },
             ],
         }
+    }
+
+    #[test]
+    fn semantic_action_sanitization_keeps_requested_default_value() {
+        let policy_type = PolicyType {
+            name: "EmailPolicy".to_string(),
+            fields: vec![
+                Field::Bool {
+                    name: "unread".to_string(),
+                    default: Some(true),
+                    on_conflict: OnConflict::Default,
+                },
+                Field::StringEnum {
+                    name: "priority".to_string(),
+                    values: vec!["low".to_string(), "medium".to_string(), "high".to_string()],
+                    default: None,
+                    on_conflict: OnConflict::LargestValue,
+                },
+                Field::StringEnum {
+                    name: "category".to_string(),
+                    values: vec![
+                        "ai".to_string(),
+                        "distributed systems".to_string(),
+                        "other".to_string(),
+                    ],
+                    default: Some("other".to_string()),
+                    on_conflict: OnConflict::Agreement,
+                },
+                Field::StringArray {
+                    name: "labels".to_string(),
+                },
+            ],
+        };
+        let action = policy_type.sanitize_semantic_action(
+            "When the email is about AI: Set \"priority\" to \"low\" and \"unread\" to \"true\".",
+            serde_json::json!({
+                "priority": "low",
+                "category": "ai",
+                "labels": [],
+                "unread": true
+            }),
+        );
+
+        assert_eq!(
+            serde_json::json!({"priority": "low", "unread": true}),
+            action
+        );
+    }
+
+    #[test]
+    fn semantic_action_sanitization_keeps_single_field_without_name_mention() {
+        let policy_type = PolicyType {
+            name: "EmailPolicy".to_string(),
+            fields: vec![Field::Number {
+                name: "weight".to_string(),
+                default: None,
+                on_conflict: OnConflict::Default,
+            }],
+        };
+        let action = policy_type.sanitize_semantic_action(
+            "Assign weight to the email.",
+            serde_json::json!({"weight": 1.25}),
+        );
+
+        assert_eq!(serde_json::json!({"weight": 1.25}), action);
     }
 
     #[test]
@@ -617,13 +740,14 @@ mod tests {
     #[test]
     fn sanitize_semantic_action_drops_unknown_fields() {
         let policy_type = create_test_policy_type();
-        let mut action = serde_json::json!({
+        let action = policy_type.sanitize_semantic_action(
+            "Set active to true and priority to high.",
+            serde_json::json!({
             "active": true,
             "priority": "high",
             "extra": "ignored",
-        });
-
-        policy_type.sanitize_semantic_action(&mut action);
+            }),
+        );
 
         assert_eq!(
             serde_json::json!({
@@ -637,14 +761,15 @@ mod tests {
     #[test]
     fn sanitize_semantic_action_coerces_simple_values() {
         let policy_type = create_test_policy_type();
-        let mut action = serde_json::json!({
-            "active": "true",
-            "score": "42.5",
-            "tags": ["example"],
-            "extra": "ignored",
-        });
-
-        policy_type.sanitize_semantic_action(&mut action);
+        let action = policy_type.sanitize_semantic_action(
+            "Set active to true, score to 42.5, and tags to example.",
+            serde_json::json!({
+                "active": "true",
+                "score": "42.5",
+                "tags": ["example"],
+                "extra": "ignored",
+            }),
+        );
 
         assert_eq!(
             serde_json::json!({

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,6 +7,12 @@ use crate::{
     StringArrayMask, StringEnumMask, StringMask,
 };
 
+fn enum_value_is_greater(existing: &str, new: &str, values: &[String]) -> bool {
+    let existing_index = values.iter().position(|value| value == existing);
+    let new_index = values.iter().position(|value| value == new);
+    matches!((existing_index, new_index), (Some(existing), Some(new)) if new > existing)
+}
+
 /// Statistics for a single field in a report.
 ///
 /// Tracks how many times a field was set and the distribution of values
@@ -457,9 +463,6 @@ impl Report {
                             OnConflict::LargestValue => {
                                 if number_less_than(existing, &value) {
                                     *existing = value;
-                                } else {
-                                    conflict_to_report =
-                                        Some((field.to_string(), existing.clone(), value.clone()));
                                 }
                             }
                         }
@@ -629,13 +632,15 @@ impl Report {
     /// # use policyai::{Report, OnConflict};
     /// # use claudius::MessageParam;
     /// let mut report = Report::new(vec![], vec![], vec![], vec![], vec![], vec![], vec![]);
-    /// report.report_string_enum(1, "status", "active".to_string(), OnConflict::LargestValue);
+    /// let values = vec!["inactive".to_string(), "active".to_string()];
+    /// report.report_string_enum(1, "status", "active".to_string(), &values, OnConflict::LargestValue);
     /// ```
     pub fn report_string_enum(
         &mut self,
         policy_index: usize,
         field: &str,
         value: String,
+        values: &[String],
         on_conflict: OnConflict,
     ) {
         self.report_policy_index(policy_index);
@@ -658,11 +663,8 @@ impl Report {
                                 self.report_string_conflict(field, s, value);
                             }
                             OnConflict::LargestValue => {
-                                if value.len() > s.len() {
+                                if enum_value_is_greater(s, &value, values) {
                                     *v = value.into();
-                                } else {
-                                    let s = s.clone();
-                                    self.report_string_conflict(field, s, value);
                                 }
                             }
                         }
@@ -1038,9 +1040,28 @@ mod tests {
     #[test]
     fn report_tracks_string_enum_stats() {
         let mut report = Report::new(vec![], vec![], vec![], vec![], vec![], vec![], vec![]);
-        report.report_string_enum(1, "priority", "high".to_string(), OnConflict::Default);
-        report.report_string_enum(2, "priority", "low".to_string(), OnConflict::Default);
-        report.report_string_enum(3, "priority", "high".to_string(), OnConflict::Default);
+        let values = vec!["low".to_string(), "medium".to_string(), "high".to_string()];
+        report.report_string_enum(
+            1,
+            "priority",
+            "high".to_string(),
+            &values,
+            OnConflict::Default,
+        );
+        report.report_string_enum(
+            2,
+            "priority",
+            "low".to_string(),
+            &values,
+            OnConflict::Default,
+        );
+        report.report_string_enum(
+            3,
+            "priority",
+            "high".to_string(),
+            &values,
+            OnConflict::Default,
+        );
 
         let stats = report
             .field_stats("priority")
@@ -1071,6 +1092,47 @@ mod tests {
             "report_tracks_string_array_stats: count={}, distribution={:?}",
             stats.count, stats.distribution
         );
+    }
+
+    #[test]
+    fn report_number_largest_value_keeps_largest_without_conflict() {
+        let mut report = Report::new(vec![], vec![], vec![], vec![], vec![], vec![], vec![]);
+        report.report_number(1, "score", 10, OnConflict::LargestValue);
+        report.report_number(2, "score", 20, OnConflict::LargestValue);
+        report.report_number(3, "score", 5, OnConflict::LargestValue);
+
+        assert_eq!(serde_json::json!({"score": 20}), report.value());
+        assert!(report.conflicts().is_empty());
+    }
+
+    #[test]
+    fn report_string_enum_largest_value_uses_declared_order() {
+        let mut report = Report::new(vec![], vec![], vec![], vec![], vec![], vec![], vec![]);
+        let values = vec!["low".to_string(), "medium".to_string(), "high".to_string()];
+        report.report_string_enum(
+            1,
+            "priority",
+            "medium".to_string(),
+            &values,
+            OnConflict::LargestValue,
+        );
+        report.report_string_enum(
+            2,
+            "priority",
+            "high".to_string(),
+            &values,
+            OnConflict::LargestValue,
+        );
+        report.report_string_enum(
+            3,
+            "priority",
+            "medium".to_string(),
+            &values,
+            OnConflict::LargestValue,
+        );
+
+        assert_eq!(serde_json::json!({"priority": "high"}), report.value());
+        assert!(report.conflicts().is_empty());
     }
 
     #[test]

--- a/src/report_builder.rs
+++ b/src/report_builder.rs
@@ -205,6 +205,7 @@ impl ReportBuilder {
                         name.clone(),
                         mask.clone(),
                         enum_value.clone(),
+                        values.clone(),
                         default.clone(),
                         *on_conflict,
                     ));


### PR DESCRIPTION
Replace panicking Manager::add with a Result-returning method that
produces a PolicyTypeMismatch error when policy types disagree.  Remove
unused production dependencies (reqwest, rustyline, shvar, utf8path)
and move guacamole and rand to dev-dependencies.

Switch semantic-injection generation to forced tool_use with
strict schema validation, and add a sanitize_semantic_action pass that
strips fields not explicitly mentioned in the injection text.  Refine
the generation prompt to prevent the LLM from inferring output fields
from policy-applicability conditions.

Fix LargestValue conflict resolution for StringEnum fields to
use the declared values order instead of string length, and stop
emitting spurious conflicts for Number fields that already pick the
larger value.  Thread the declared values list through StringEnumMask
and Report.

Replace todo!() in policyai-evaluate-policies with descriptive
ApplyError variants and propagate the new Result from Manager::add.
Gate live Anthropic tests behind the POLICYAI_LIVE_TESTS env var,
update CI to workflow_dispatch, and bump the README version to 0.4.

Co-authored-by: AI
