### PR TITLE
feat: enable adaptive thinking and medium effort for API calls

### DIFF
--- a/examples/generate-semantic-injections.rs
+++ b/examples/generate-semantic-injections.rs
@@ -2,7 +2,10 @@ use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader};
 
 use arrrg::CommandLine;
-use claudius::{Anthropic, CacheControlEphemeral, Model, SystemPrompt, TextBlock, ThinkingConfig};
+use claudius::{
+    Anthropic, CacheControlEphemeral, Effort, Model, OutputConfig, SystemPrompt, TextBlock,
+    ThinkingConfig,
+};
 use rand::prelude::*;
 
 #[derive(Clone, Default, Debug, Eq, PartialEq, arrrg_derive::CommandLine)]
@@ -90,7 +93,7 @@ Text:
                 model: model.clone(),
                 cache_control: None,
                 metadata: None,
-                output_config: None,
+                output_config: Some(OutputConfig::new().with_effort(Effort::Medium)),
                 output_format: None,
                 stop_sequences: None,
                 system: Some(SystemPrompt::from_blocks(vec![TextBlock {
@@ -99,7 +102,7 @@ Text:
                     citations: None,
                 }])),
                 temperature: None,
-                thinking: Some(ThinkingConfig::enabled(1024)),
+                thinking: Some(ThinkingConfig::adaptive()),
                 tool_choice: None,
                 tools: None,
                 top_k: None,

--- a/src/policy_type.rs
+++ b/src/policy_type.rs
@@ -1,6 +1,6 @@
 use claudius::{
-    Anthropic, ContentBlock, JsonSchema, MessageCreateParams, MessageParam, MessageRole, Model,
-    ToolChoice,
+    Anthropic, ContentBlock, Effort, JsonSchema, MessageCreateParams, MessageParam, MessageRole,
+    Model, OutputConfig, ThinkingConfig, ToolChoice,
 };
 use uuid::Uuid;
 
@@ -152,9 +152,9 @@ impl PolicyType {
                 MessageRole::User,
             )],
             system: Some(system.into()),
-            thinking: None,
+            thinking: Some(ThinkingConfig::adaptive()),
             metadata: None,
-            output_config: None,
+            output_config: Some(OutputConfig::new().with_effort(Effort::Medium)),
             output_format: None,
             stop_sequences: None,
             temperature: None,


### PR DESCRIPTION
Configure OutputConfig with Effort::Medium and ThinkingConfig::adaptive()
in both generate-semantic-injections and PolicyType classification.
This replaces the fixed thinking budget of 1024 tokens in the
injection generator and adds thinking to policy type classification
which previously had none.

Co-authored-by: AI
