### PR TITLE
build: parameterize Hypermakefile by model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,12 @@ arrrg = "0.10.0"
 arrrg_derive = "0.10.0"
 claudius = "0.31.0"
 getopts = "0.2.24"
+guacamole = "0.16.0"
 serde = "1.0.228"
 serde_json = { version = "1.0.150", features = ["preserve_order"] }
 tokio = { version = "1.52.3", features = ["rt", "macros"] }
-uuid = { version = "1.18.1", features = ["v4"] }
 
 [dev-dependencies]
 biometrics = "0.14"
 biometrics_prometheus = "0.12"
-guacamole = "0.16.0"
 rand = "0.10.1"

--- a/Hypermakefile
+++ b/Hypermakefile
@@ -2,15 +2,17 @@ TEXTS := data/ai-tweets.jsonl
 MODEL := accounts/fireworks/models/kimi-k2p6
 MODEL_ALIAS := kimi-k2p6
 MAX_TOKENS := 16384
-THINKING_ARGS := --thinking adaptive --effort high
-RUN_ALIAS := $(MODEL_ALIAS)-adaptive-high-$(MAX_TOKENS)
+THINKING_ARGS := --thinking 1024
+MAX_ATTEMPTS_PER_POLICY := 10
+RUN_ALIAS := kimi-k2p6-think-1024
 SEMANTIC_INJECTIONS := 2
 POLICIES_PER_TEXT := 5
-NEGATIVES_PER_TEXT := 1
+NEGATIVES_PER_TEXT := 6
 DATA_TYPE := ( bool number string enum-field array )
 CONFLICT_RATE := 0
 TEST_CASES := 10
-MATCHING := ( 0 1 2 3 4 5 )
+#MATCHING := ( 0 1 2 3 4 5 )
+MATCHING := ( 0 1 )
 POLICIES := 5
 
 K := 3
@@ -21,7 +23,7 @@ N := 3
 all: @data/report-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl @data/regressions-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
 
 data/semantic-injections-$(RUN_ALIAS).jsonl: $(TEXTS)
-	cargo run --example generate-semantic-injections -- --model $(MODEL) --max-tokens $(MAX_TOKENS) $(THINKING_ARGS) --samples $(SEMANTIC_INJECTIONS) --policies $(POLICIES_PER_TEXT) --success $(K) --total $(N) $< > $@
+	cargo run --example generate-semantic-injections -- --model $(MODEL) --max-tokens $(MAX_TOKENS) $(THINKING_ARGS) --max-attempts-per-policy $(MAX_ATTEMPTS_PER_POLICY) --samples $(SEMANTIC_INJECTIONS) --policies $(POLICIES_PER_TEXT) --success $(K) --total $(N) $< > $@
 
 data/decidables-$(RUN_ALIAS).jsonl: data/semantic-injections-$(RUN_ALIAS).jsonl
 	cargo run --example generate-decidables -- --model $(MODEL) --max-tokens $(MAX_TOKENS) $(THINKING_ARGS) --policies $(NEGATIVES_PER_TEXT) --success $(K) --total $(N) $< > $@

--- a/Hypermakefile
+++ b/Hypermakefile
@@ -1,18 +1,19 @@
 TEXTS := data/ai-tweets.jsonl
-MODEL := accounts/fireworks/models/kimi-k2p6
-MODEL_ALIAS := kimi-k2p6
+#MODEL := accounts/fireworks/models/kimi-k2p6
+#MODEL_ALIAS := kimi-k2p6
+MODEL := accounts/fireworks/models/gpt-oss-120b
+MODEL_ALIAS := gpt-oss-120b
 MAX_TOKENS := 16384
 THINKING_ARGS := --thinking 1024
 MAX_ATTEMPTS_PER_POLICY := 10
-RUN_ALIAS := kimi-k2p6-think-1024
-SEMANTIC_INJECTIONS := 2
-POLICIES_PER_TEXT := 5
-NEGATIVES_PER_TEXT := 6
+RUN_ALIAS := gpt-oss-120b-think-1024
+SEMANTIC_INJECTIONS := 10
+POLICIES_PER_TEXT := 10
+NEGATIVES_PER_TEXT := 10
 DATA_TYPE := ( bool number string enum-field array )
 CONFLICT_RATE := 0
 TEST_CASES := 10
-#MATCHING := ( 0 1 2 3 4 5 )
-MATCHING := ( 0 1 )
+MATCHING := ( 0 1 2 3 4 5 )
 POLICIES := 5
 
 K := 3

--- a/Hypermakefile
+++ b/Hypermakefile
@@ -1,12 +1,14 @@
 TEXTS := data/ai-tweets.jsonl
+MODEL := claude-opus-4-8
+MODEL_ALIAS := opus-4-8
+RUN_ALIAS := opus-4-8-think-adaptive
 #MODEL := accounts/fireworks/models/kimi-k2p6
 #MODEL_ALIAS := kimi-k2p6
-MODEL := accounts/fireworks/models/gpt-oss-120b
-MODEL_ALIAS := gpt-oss-120b
+#RUN_ALIAS := kimi-k2p6-think-1024
 MAX_TOKENS := 16384
-THINKING_ARGS := --thinking 1024
+THINKING_ARGS := --thinking adaptive
+REPORT_THINKING_ARGS :=
 MAX_ATTEMPTS_PER_POLICY := 10
-RUN_ALIAS := gpt-oss-120b-think-1024
 SEMANTIC_INJECTIONS := 10
 POLICIES_PER_TEXT := 10
 NEGATIVES_PER_TEXT := 10
@@ -36,7 +38,7 @@ data/test-data-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/act
 	cargo run --example generate-test-data -- --actions data/actions-$(DATA_TYPE).jsonl --decidables data/decidables-$(RUN_ALIAS).jsonl --conflict-rate $(CONFLICT_RATE) --samples $(TEST_CASES) --policies "$(POLICIES)" --matching "$(MATCHING)" --policy data/policy > $@
 
 data/report-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/test-data-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
-	cargo run --bin policyai-evaluate-policies -- --model $(MODEL) --max-tokens $(MAX_TOKENS) $(THINKING_ARGS) $< > $@
+	cargo run --bin policyai-evaluate-policies -- --model $(MODEL) --max-tokens $(MAX_TOKENS) $(REPORT_THINKING_ARGS) $< > $@
 
 data/regressions-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/report-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
 	cargo run --bin policyai-extract-regressions -- --include-baseline-failures $< > $@

--- a/Hypermakefile
+++ b/Hypermakefile
@@ -1,8 +1,12 @@
 TEXTS := data/ai-tweets.jsonl
-MODEL := claude-opus-4-8
-SEMANTIC_INJECTIONS := 10
-POLICIES_PER_TEXT := 10
-NEGATIVES_PER_TEXT := 10
+MODEL := accounts/fireworks/models/kimi-k2p6
+MODEL_ALIAS := kimi-k2p6
+MAX_TOKENS := 16384
+THINKING_ARGS := --thinking adaptive --effort high
+RUN_ALIAS := $(MODEL_ALIAS)-adaptive-high-$(MAX_TOKENS)
+SEMANTIC_INJECTIONS := 2
+POLICIES_PER_TEXT := 5
+NEGATIVES_PER_TEXT := 1
 DATA_TYPE := ( bool number string enum-field array )
 CONFLICT_RATE := 0
 TEST_CASES := 10
@@ -14,22 +18,22 @@ N := 3
 
 .PHONY: all
 
-all: @data/report-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl @data/regressions-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
+all: @data/report-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl @data/regressions-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
 
-data/semantic-injections-$(MODEL).jsonl: $(TEXTS)
-	cargo run --example generate-semantic-injections -- --model $(MODEL) --samples $(SEMANTIC_INJECTIONS) --policies $(POLICIES_PER_TEXT) --success $(K) --total $(N) $< > $@
+data/semantic-injections-$(RUN_ALIAS).jsonl: $(TEXTS)
+	cargo run --example generate-semantic-injections -- --model $(MODEL) --max-tokens $(MAX_TOKENS) $(THINKING_ARGS) --samples $(SEMANTIC_INJECTIONS) --policies $(POLICIES_PER_TEXT) --success $(K) --total $(N) $< > $@
 
-data/decidables-$(MODEL).jsonl: data/semantic-injections-$(MODEL).jsonl
-	cargo run --example generate-decidables -- --model $(MODEL) --policies $(NEGATIVES_PER_TEXT) --success $(K) --total $(N) $< > $@
+data/decidables-$(RUN_ALIAS).jsonl: data/semantic-injections-$(RUN_ALIAS).jsonl
+	cargo run --example generate-decidables -- --model $(MODEL) --max-tokens $(MAX_TOKENS) $(THINKING_ARGS) --policies $(NEGATIVES_PER_TEXT) --success $(K) --total $(N) $< > $@
 
 data/actions-$(DATA_TYPE).jsonl: data/policy
 	cargo run --example generate-actions -- --$(DATA_TYPE) < $< > $@
 
-data/test-data-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/actions-$(DATA_TYPE).jsonl data/decidables-$(MODEL).jsonl
-	cargo run --example generate-test-data -- --actions data/actions-$(DATA_TYPE).jsonl --decidables data/decidables-$(MODEL).jsonl --conflict-rate $(CONFLICT_RATE) --samples $(TEST_CASES) --policies "$(POLICIES)" --matching "$(MATCHING)" --policy data/policy > $@
+data/test-data-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/actions-$(DATA_TYPE).jsonl data/decidables-$(RUN_ALIAS).jsonl
+	cargo run --example generate-test-data -- --actions data/actions-$(DATA_TYPE).jsonl --decidables data/decidables-$(RUN_ALIAS).jsonl --conflict-rate $(CONFLICT_RATE) --samples $(TEST_CASES) --policies "$(POLICIES)" --matching "$(MATCHING)" --policy data/policy > $@
 
-data/report-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/test-data-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
-	cargo run --bin policyai-evaluate-policies -- --model $(MODEL) $< > $@
+data/report-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/test-data-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
+	cargo run --bin policyai-evaluate-policies -- --model $(MODEL) --max-tokens $(MAX_TOKENS) $(THINKING_ARGS) $< > $@
 
-data/regressions-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/report-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
+data/regressions-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/report-$(RUN_ALIAS)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
 	cargo run --bin policyai-extract-regressions -- --include-baseline-failures $< > $@

--- a/Hypermakefile
+++ b/Hypermakefile
@@ -1,5 +1,6 @@
 TEXTS := data/ai-tweets.jsonl
-SEMANTIC_INJECTIONS := 1000
+MODEL := claude-opus-4-8
+SEMANTIC_INJECTIONS := 10
 POLICIES_PER_TEXT := 10
 NEGATIVES_PER_TEXT := 10
 DATA_TYPE := ( bool number string enum-field array )
@@ -13,22 +14,22 @@ N := 3
 
 .PHONY: all
 
-all: @data/report-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl @data/regressions-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
+all: @data/report-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl @data/regressions-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
 
-data/semantic-injections.jsonl: $(TEXTS)
-	cargo run --example generate-semantic-injections -- --samples $(SEMANTIC_INJECTIONS) --policies $(POLICIES_PER_TEXT) --success $(K) --total $(N) $< > $@
+data/semantic-injections-$(MODEL).jsonl: $(TEXTS)
+	cargo run --example generate-semantic-injections -- --model $(MODEL) --samples $(SEMANTIC_INJECTIONS) --policies $(POLICIES_PER_TEXT) --success $(K) --total $(N) $< > $@
 
-data/decidables.jsonl: data/semantic-injections.jsonl
-	cargo run --example generate-decidables -- --policies $(NEGATIVES_PER_TEXT) --success $(K) --total $(N) $< > $@
+data/decidables-$(MODEL).jsonl: data/semantic-injections-$(MODEL).jsonl
+	cargo run --example generate-decidables -- --model $(MODEL) --policies $(NEGATIVES_PER_TEXT) --success $(K) --total $(N) $< > $@
 
 data/actions-$(DATA_TYPE).jsonl: data/policy
 	cargo run --example generate-actions -- --$(DATA_TYPE) < $< > $@
 
-data/test-data-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/actions-$(DATA_TYPE).jsonl data/decidables.jsonl
-	cargo run --example generate-test-data -- --actions data/actions-$(DATA_TYPE).jsonl --decidables data/decidables.jsonl --conflict-rate $(CONFLICT_RATE) --samples $(TEST_CASES) --policies "$(POLICIES)" --matching "$(MATCHING)" --policy data/policy > $@
+data/test-data-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/actions-$(DATA_TYPE).jsonl data/decidables-$(MODEL).jsonl
+	cargo run --example generate-test-data -- --actions data/actions-$(DATA_TYPE).jsonl --decidables data/decidables-$(MODEL).jsonl --conflict-rate $(CONFLICT_RATE) --samples $(TEST_CASES) --policies "$(POLICIES)" --matching "$(MATCHING)" --policy data/policy > $@
 
-data/report-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/test-data-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
-	cargo run --bin policyai-evaluate-policies -- $< > $@
+data/report-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/test-data-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
+	cargo run --bin policyai-evaluate-policies -- --model $(MODEL) $< > $@
 
-data/regressions-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/report-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
+data/regressions-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl: data/report-$(MODEL)-$(DATA_TYPE)-$(MATCHING)-$(POLICIES).jsonl
 	cargo run --bin policyai-extract-regressions -- --include-baseline-failures $< > $@

--- a/examples/generate-decidables.rs
+++ b/examples/generate-decidables.rs
@@ -24,7 +24,7 @@ struct Options {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), std::io::Error> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (options, free) = Options::from_command_line_relaxed(
         "USAGE: policyai-generate-decidables [OPTIONS] SEMANTIC-INJECTIONS",
     );
@@ -65,8 +65,7 @@ async fn main() -> Result<(), std::io::Error> {
                 options.total,
                 model.clone(),
             )
-            .await
-            .unwrap()
+            .await?
             {
                 negatives.push(policy_fragment.clone());
             }

--- a/examples/generate-decidables.rs
+++ b/examples/generate-decidables.rs
@@ -2,7 +2,8 @@ use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader};
 
 use arrrg::CommandLine;
-use claudius::{Anthropic, Model};
+use claudius::{Anthropic, Effort, Model};
+use policyai::data::{EffortArg, ThinkingArg};
 use rand::prelude::*;
 
 #[derive(Clone, Default, Debug, Eq, PartialEq, arrrg_derive::CommandLine)]
@@ -21,6 +22,12 @@ struct Options {
     total: usize,
     #[arrrg(optional, "Anthropic model to use for verification.")]
     model: Option<String>,
+    #[arrrg(optional, "Maximum output tokens for each verification request.")]
+    max_tokens: Option<u32>,
+    #[arrrg(optional, "Thinking config: adaptive, disabled, or a token budget.")]
+    thinking: Option<ThinkingArg>,
+    #[arrrg(optional, "Adaptive thinking effort: low, medium, or high.")]
+    effort: Option<EffortArg>,
 }
 
 #[tokio::main]
@@ -37,6 +44,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .as_deref()
         .map(|model| model.parse::<Model>().unwrap())
         .unwrap_or(policyai::DEFAULT_MODEL);
+    let max_tokens = options.max_tokens.unwrap_or(1030);
+    let thinking = Some(
+        options
+            .thinking
+            .map(Into::into)
+            .unwrap_or_else(claudius::ThinkingConfig::adaptive),
+    );
+    let effort = Some(options.effort.map(Into::into).unwrap_or(Effort::High));
     let client = Anthropic::new(None)
         .expect("could not connect to claude")
         .with_max_retries(10)
@@ -64,6 +79,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 options.success,
                 options.total,
                 model.clone(),
+                max_tokens,
+                thinking,
+                effort,
             )
             .await?
             {

--- a/examples/generate-semantic-injections.rs
+++ b/examples/generate-semantic-injections.rs
@@ -2,10 +2,8 @@ use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader};
 
 use arrrg::CommandLine;
-use claudius::{
-    Anthropic, CacheControlEphemeral, Effort, Model, OutputConfig, SystemPrompt, TextBlock,
-    ThinkingConfig,
-};
+use claudius::{Anthropic, CacheControlEphemeral, Effort, Model, SystemPrompt, TextBlock};
+use policyai::data::{EffortArg, ThinkingArg};
 use rand::prelude::*;
 
 #[derive(Clone, Default, Debug, Eq, PartialEq, arrrg_derive::CommandLine)]
@@ -26,6 +24,12 @@ struct Options {
     total: usize,
     #[arrrg(optional, "Anthropic model to use for generation and verification.")]
     model: Option<String>,
+    #[arrrg(optional, "Maximum output tokens for generation and verification.")]
+    max_tokens: Option<u32>,
+    #[arrrg(optional, "Thinking config: adaptive, disabled, or a token budget.")]
+    thinking: Option<ThinkingArg>,
+    #[arrrg(optional, "Adaptive thinking effort: low, medium, or high.")]
+    effort: Option<EffortArg>,
 }
 
 #[tokio::main]
@@ -41,6 +45,14 @@ async fn main() -> Result<(), claudius::Error> {
         .as_deref()
         .map(|model| model.parse::<Model>().unwrap())
         .unwrap_or(policyai::DEFAULT_MODEL);
+    let max_tokens = options.max_tokens.unwrap_or(2048);
+    let thinking = Some(
+        options
+            .thinking
+            .map(Into::into)
+            .unwrap_or_else(claudius::ThinkingConfig::adaptive),
+    );
+    let effort = Some(options.effort.map(Into::into).unwrap_or(Effort::High));
     let texts_file = BufReader::new(OpenOptions::new().read(true).open(&free[0]).unwrap());
     let mut texts = vec![];
     for line in texts_file.lines() {
@@ -88,12 +100,12 @@ Text:
 "#
             );
             let req = claudius::MessageCreateParams {
-                max_tokens: 2048,
+                max_tokens,
                 messages: vec![prompt.into()],
                 model: model.clone(),
                 cache_control: None,
                 metadata: None,
-                output_config: Some(OutputConfig::new().with_effort(Effort::Medium)),
+                output_config: policyai::data::output_config_for_thinking(thinking, effort),
                 output_format: None,
                 stop_sequences: None,
                 system: Some(SystemPrompt::from_blocks(vec![TextBlock {
@@ -102,7 +114,7 @@ Text:
                     citations: None,
                 }])),
                 temperature: None,
-                thinking: Some(ThinkingConfig::adaptive()),
+                thinking,
                 tool_choice: None,
                 tools: None,
                 top_k: None,
@@ -128,6 +140,9 @@ Text:
                 options.success,
                 options.total,
                 model.clone(),
+                max_tokens,
+                thinking,
+                effort,
             )
             .await?
             {

--- a/examples/generate-semantic-injections.rs
+++ b/examples/generate-semantic-injections.rs
@@ -30,6 +30,8 @@ struct Options {
     thinking: Option<ThinkingArg>,
     #[arrrg(optional, "Adaptive thinking effort: low, medium, or high.")]
     effort: Option<EffortArg>,
+    #[arrrg(optional, "Maximum candidate attempts per accepted policy.")]
+    max_attempts_per_policy: Option<usize>,
 }
 
 #[tokio::main]
@@ -46,6 +48,7 @@ async fn main() -> Result<(), claudius::Error> {
         .map(|model| model.parse::<Model>().unwrap())
         .unwrap_or(policyai::DEFAULT_MODEL);
     let max_tokens = options.max_tokens.unwrap_or(2048);
+    let max_attempts = options.max_attempts_per_policy.unwrap_or(10) * options.policies;
     let thinking = Some(
         options
             .thinking
@@ -73,7 +76,9 @@ async fn main() -> Result<(), claudius::Error> {
         let text = texts.choose(&mut rng).unwrap();
         let mut injections: Vec<String> = vec![];
         let mut rationales: Vec<String> = vec![];
-        while injections.len() < options.policies {
+        let mut attempts = 0;
+        while injections.len() < options.policies && attempts < max_attempts {
+            attempts += 1;
             let system = r#"
 You are an expert writer.  We are developing an instruction-processing engine that takes as input
 instructions and text to output JSON.  Every instruction has two parts, first it has the _semantic
@@ -148,7 +153,25 @@ Text:
             {
                 injections.push(injection);
                 rationales.push(thought);
+                eprintln!(
+                    "accepted {} of {} policies after {attempts} attempts",
+                    injections.len(),
+                    options.policies
+                );
+            } else {
+                eprintln!(
+                    "rejected candidate; accepted {} of {} policies after {attempts} attempts",
+                    injections.len(),
+                    options.policies
+                );
             }
+        }
+        if injections.len() < options.policies {
+            return Err(claudius::Error::unknown(format!(
+                "only generated {} of {} semantic injections after {attempts} attempts",
+                injections.len(),
+                options.policies
+            )));
         }
         println!(
             "{}",

--- a/prompts/manager.md
+++ b/prompts/manager.md
@@ -1,7 +1,8 @@
 # Output JSON
 <summary>
-- Output JSON if and only if a rule matches.  Be discerning.
-- If a rule does not match, output the default JSON.
+- Always output one valid JSON object.
+- Output a rule's action fields if and only if that rule matches.  Be discerning.
+- If no rules match, output the default JSON plus "__rule_numbers__": [] and "__justification__".
 - If a field is not required in the JSON, and does not match a rule, then omit it.
 </summary>
 <context>
@@ -12,6 +13,8 @@ You will be provided with a default value, zero or more rules, and user-provide 
 - For each field in the JSON output:
     - Determine the default value and any and all rules that impact the value.
     - Output the value according to the descriptions in the matching rules.
+- Always include "__rule_numbers__" as the sorted list of matching rule indexes.
+- Always include "__justification__" explaining why the listed rules match and why the omitted rules do not.
 </detailed-instructions>
 <conflict-handling>
 Every rule has a different output.  There will be no conflicts.
@@ -27,10 +30,12 @@ Every rule has a different output.  There will be no conflicts.
 </input>
 <output>
 {
-    "3256dda3-bbd1-4d8d-ba29-e6ebe8bb8f42": [],
-    "b22a89fc-8ad6-48e7-8e25-47f3c2929782": [],
-    "0b84dfeb-f93f-4819-8f2a-26659f85023a": [],
-    "e43d3cdf-1f52-4b65-b16f-58fe32d6ca9d": []
+  "__rule_numbers__": [1, 2, 3, 5],
+  "__justification__": "Rules 1, 2, 3, and 5 match the text's enthusiasm about learning to code as a language-like path to digital opportunity. Rule 4 does not match because the text does not discuss history, mathematics, or logic.",
+  "3256dda3-bbd1-4d8d-ba29-e6ebe8bb8f42": [],
+  "b22a89fc-8ad6-48e7-8e25-47f3c2929782": [],
+  "0b84dfeb-f93f-4819-8f2a-26659f85023a": [],
+  "e43d3cdf-1f52-4b65-b16f-58fe32d6ca9d": []
 }
 </output>
 </example>
@@ -40,11 +45,9 @@ Every rule has a different output.  There will be no conflicts.
 </input>
 <output>
 {
-  "__rule_numbers__": [
-    1
-  ],
-  "__justification__": "The text matches rule 1. It contains an enthusiastic social media post (indicated by the exclamation marks and hashtags #AI #TechTalk) about artificial intelligence's current impact (\"it's reshaping our present\") and asks readers about exciting AI advancements they've observed (\"What advancements have you seen that excite you?\"). No other rules match: rule 2 doesn't match because it doesn't discuss AI advancements across multiple sectors; rules 3 and 4 don't match because it doesn't promote learning AI or recommend Python; rule 5 doesn't match because it doesn't discuss quantum computing."
-  "1c5741ca-4431-409d-a044-66d4b0f0f350": "line1\nline2\nindex:175",
+  "__rule_numbers__": [1],
+  "__justification__": "Rule 1 matches because the text enthusiastically says AI is reshaping the present and asks readers what advancements excite them. Rules 2, 3, 4, and 5 do not match.",
+  "1c5741ca-4431-409d-a044-66d4b0f0f350": "line1\nline2\nindex:175"
 }
 </output>
 </example>
@@ -54,13 +57,8 @@ Every rule has a different output.  There will be no conflicts.
 </input>
 <output>
 {
-  "__rule_numbers__": [1],
-  "__justification__": "The text does not match any of the rules. Rule 1 requires discussion of machine learning advancements and computers replicating human decision-making, but the text only makes a general statement about AI being a revolution. Rule 2 requires advocacy for inclusive and beneficial AI through collaboration, which is not present. Rule 3 requires enthusiasm about quantum computing for AI and asking readers about their excitement, but the text doesn't mention quantum computing. Rule 4 requires explanation of computer science's foundational role with technical components like algorithms and data structures, which are not discussed. Rule 5 requires discussion of human-AI collaboration in the workplace and encouragement to adapt to change, which is not present. The text is simply a general statement about AI being transformative. Therefore, the default JSON should be output.",
-  "da4b64fd-c521-490e-aeb9-1b414d9399f0": true,
-  "5da1e557-2c50-4d7a-841e-7c26173f4d31": false,
-  "9dbe9e51-bd77-4d43-9763-d220825e37fd": false,
-  "6309ece7-2866-41b1-baa3-ebca0063d890": false,
-  "23dd33f3-65e4-4a7b-928a-506636ca0171": false
+  "__rule_numbers__": [],
+  "__justification__": "No rules match. The text is a broad statement about AI being transformative; it does not discuss machine learning decision-making, inclusive AI collaboration, quantum computing, computer science foundations, or human-AI workplace collaboration."
 }
 </output>
 </example>

--- a/prompts/manager_suffix.md
+++ b/prompts/manager_suffix.md
@@ -1,6 +1,9 @@
 <instruction reminder>
 - Evaluate the text against each rule.
-- Output JSON if and only if a rule matches.  Be discerning.
-- If a rule does not match, output the default JSON.
+- Always output one valid JSON object.
+- Output a rule's action fields if and only if that rule matches.  Be discerning.
+- If no rules match, output the default JSON.
 - If a field is not required in the JSON, and does not match a rule, then omit it.
+- Always include "__rule_numbers__" as the sorted list of rule indexes whose action fields you output.
+- If no rules match, "__rule_numbers__" must be [] and no rule action fields should be output.
 </instruction reminder>

--- a/src/bin/policyai-evaluate-policies.rs
+++ b/src/bin/policyai-evaluate-policies.rs
@@ -5,8 +5,8 @@ use std::time::Instant;
 use arrrg::CommandLine;
 use claudius::{
     push_or_merge_message, Anthropic, ContentBlock, Effort, JsonSchema, MessageCreateParams,
-    MessageParam, MessageRole, Metadata, Model, SystemPrompt, TextBlock, ThinkingConfig,
-    ToolChoice,
+    MessageParam, MessageRole, Metadata, Model, OutputFormat, SystemPrompt, TextBlock,
+    ThinkingConfig,
 };
 
 use policyai::data::{EffortArg, EvaluationReport, Metrics, TestDataPoint, ThinkingArg};
@@ -99,16 +99,7 @@ pub async fn naive_apply(
     schema["type"] = "object".into();
     schema["required"] = serde_json::Value::Array(vec![]);
     schema["properties"] = properties;
-    req.tool_choice = Some(ToolChoice::tool("output_json"));
-    req.tools = Some(vec![claudius::ToolUnionParam::CustomTool(
-        claudius::ToolParam {
-            name: "output_json".to_string(),
-            description: Some("output JSON according to policy".to_string()),
-            input_schema: schema,
-            cache_control: None,
-            strict: None,
-        },
-    )]);
+    configure_baseline_structured_output(&mut req, schema);
     let start_time = Instant::now();
     let resp = client.send(req).await?;
 
@@ -120,22 +111,56 @@ pub async fn naive_apply(
         u.set_wall_clock_time(start_time.elapsed());
     }
 
-    if resp.content.len() != 1 {
+    extract_baseline_response(&resp.content)
+}
+
+fn configure_baseline_structured_output(req: &mut MessageCreateParams, schema: serde_json::Value) {
+    req.tool_choice = None;
+    req.tools = None;
+    if let Some(output_config) = &mut req.output_config {
+        req.output_format = None;
+        output_config.format = Some(OutputFormat::json_schema(schema));
+    } else {
+        req.output_format = Some(OutputFormat::json_schema(schema));
+    }
+}
+
+fn extract_baseline_response(content: &[ContentBlock]) -> Result<serde_json::Value, ApplyError> {
+    let mut json_text_blocks = 0;
+    let mut other_blocks = 0;
+    let mut text = None;
+    for block in content {
+        match block {
+            ContentBlock::Thinking(_) | ContentBlock::RedactedThinking(_) => {}
+            ContentBlock::Text(t) if !t.text.trim().is_empty() => {
+                json_text_blocks += 1;
+                text = Some(t.text.trim());
+            }
+            _ => other_blocks += 1,
+        }
+    }
+    let Some(text) = text else {
         return Err(ApplyError::invalid_response(
             format!(
-                "Expected exactly 1 content block, got {}",
-                resp.content.len()
+                "Expected exactly 1 JSON text block after ignoring thinking blocks, got {json_text_blocks} JSON text blocks and {other_blocks} other blocks"
             ),
-            "The baseline evaluator expects the model to call the output_json tool once",
-        ));
-    }
-    let ContentBlock::ToolUse(t) = &resp.content[0] else {
-        return Err(ApplyError::invalid_response(
-            "Expected ToolUse content block",
-            "The baseline evaluator expects the model to use the output_json tool",
+            "The baseline evaluator expects JSON schema text output",
         ));
     };
-    Ok(t.input.clone())
+    if json_text_blocks != 1 || other_blocks != 0 {
+        return Err(ApplyError::invalid_response(
+            format!(
+                "Expected exactly 1 JSON text block after ignoring thinking blocks, got {json_text_blocks} JSON text blocks and {other_blocks} other blocks"
+            ),
+            "The baseline evaluator expects JSON schema text output",
+        ));
+    }
+    serde_json::from_str(text).map_err(|err| {
+        ApplyError::invalid_response(
+            format!("Could not parse baseline JSON response: {err}"),
+            "Check that the baseline model response is valid JSON for the configured schema",
+        )
+    })
 }
 
 fn values_match(expected: &serde_json::Value, actual: &serde_json::Value) -> bool {
@@ -426,6 +451,31 @@ impl From<CliOptions> for RuntimeOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use claudius::ThinkingBlock;
+
+    #[test]
+    fn baseline_response_ignores_thinking_blocks() {
+        let content = vec![
+            ContentBlock::Thinking(ThinkingBlock::new("thinking", "signature")),
+            ContentBlock::Text(TextBlock::new(r#"{"field":"value"}"#)),
+        ];
+
+        let extracted = extract_baseline_response(&content).unwrap();
+
+        assert_eq!(extracted, serde_json::json!({"field": "value"}));
+    }
+
+    #[test]
+    fn baseline_response_rejects_multiple_json_text_blocks() {
+        let content = vec![
+            ContentBlock::Text(TextBlock::new(r#"{"a":1}"#)),
+            ContentBlock::Text(TextBlock::new(r#"{"b":2}"#)),
+        ];
+
+        let err = extract_baseline_response(&content).unwrap_err();
+
+        assert!(format!("{err:?}").contains("Expected exactly 1 JSON text block"));
+    }
 
     #[test]
     fn evaluation_report_minimal() {

--- a/src/bin/policyai-evaluate-policies.rs
+++ b/src/bin/policyai-evaluate-policies.rs
@@ -2,12 +2,14 @@ use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader};
 use std::time::Instant;
 
+use arrrg::CommandLine;
 use claudius::{
-    push_or_merge_message, Anthropic, ContentBlock, JsonSchema, MessageCreateParams, MessageParam,
-    MessageRole, Metadata, Model, SystemPrompt, TextBlock, ToolChoice,
+    push_or_merge_message, Anthropic, ContentBlock, Effort, JsonSchema, MessageCreateParams,
+    MessageParam, MessageRole, Metadata, Model, SystemPrompt, TextBlock, ThinkingConfig,
+    ToolChoice,
 };
 
-use policyai::data::{EvaluationReport, Metrics, TestDataPoint};
+use policyai::data::{EffortArg, EvaluationReport, Metrics, TestDataPoint, ThinkingArg};
 use policyai::{ApplyError, Field, Manager, Policy, Report, Usage, DEFAULT_MODEL};
 
 pub async fn naive_apply(
@@ -252,7 +254,9 @@ fn calculate_field_metrics(
 
 #[tokio::main]
 async fn main() {
-    let (model, files) = parse_args();
+    let (options, files) =
+        CliOptions::from_command_line_relaxed("USAGE: policyai-evaluate-policies [OPTIONS] FILES");
+    let options = RuntimeOptions::from(options);
     let client = Anthropic::new(None).unwrap();
     for file in files {
         let file = OpenOptions::new()
@@ -287,8 +291,13 @@ async fn main() {
                 &client,
                 &point.policies,
                 &MessageCreateParams {
-                    max_tokens: 4096,
-                    model: model.clone(),
+                    max_tokens: options.max_tokens,
+                    model: options.model.clone(),
+                    thinking: options.thinking,
+                    output_config: policyai::data::output_config_for_thinking(
+                        options.thinking,
+                        options.effort,
+                    ),
                     ..Default::default()
                 },
                 &point.text,
@@ -327,8 +336,13 @@ async fn main() {
                     .apply(
                         &client,
                         MessageCreateParams {
-                            max_tokens: 4096,
-                            model: model.clone(),
+                            max_tokens: options.max_tokens,
+                            model: options.model.clone(),
+                            thinking: options.thinking,
+                            output_config: policyai::data::output_config_for_thinking(
+                                options.thinking,
+                                options.effort,
+                            ),
                             ..Default::default()
                         },
                         &point.text,
@@ -370,24 +384,43 @@ async fn main() {
     }
 }
 
-fn parse_args() -> (Model, Vec<String>) {
-    let mut model = DEFAULT_MODEL;
-    let mut files = Vec::new();
-    let mut args = std::env::args().skip(1);
-    while let Some(arg) = args.next() {
-        if arg == "--model" {
-            let Some(value) = args.next() else {
-                eprintln!("--model requires a value");
-                std::process::exit(2);
-            };
-            model = value.parse::<Model>().unwrap();
-        } else if let Some(value) = arg.strip_prefix("--model=") {
-            model = value.parse::<Model>().unwrap();
-        } else {
-            files.push(arg);
+#[derive(Clone, Default, Debug, Eq, PartialEq, arrrg_derive::CommandLine)]
+struct CliOptions {
+    #[arrrg(optional, "Anthropic model to use for evaluation.")]
+    model: Option<String>,
+    #[arrrg(optional, "Maximum output tokens for each request.")]
+    max_tokens: Option<u32>,
+    #[arrrg(optional, "Thinking config: adaptive, disabled, or a token budget.")]
+    thinking: Option<ThinkingArg>,
+    #[arrrg(optional, "Adaptive thinking effort: low, medium, or high.")]
+    effort: Option<EffortArg>,
+}
+
+struct RuntimeOptions {
+    model: Model,
+    max_tokens: u32,
+    thinking: Option<ThinkingConfig>,
+    effort: Option<Effort>,
+}
+
+impl From<CliOptions> for RuntimeOptions {
+    fn from(options: CliOptions) -> Self {
+        Self {
+            model: options
+                .model
+                .as_deref()
+                .map(|model| model.parse::<Model>().unwrap())
+                .unwrap_or(DEFAULT_MODEL),
+            max_tokens: options.max_tokens.unwrap_or(4096),
+            thinking: Some(
+                options
+                    .thinking
+                    .map(Into::into)
+                    .unwrap_or_else(ThinkingConfig::adaptive),
+            ),
+            effort: Some(options.effort.map(Into::into).unwrap_or(Effort::High)),
         }
     }
-    (model, files)
 }
 
 #[cfg(test)]

--- a/src/bin/policyai-evaluate-policies.rs
+++ b/src/bin/policyai-evaluate-policies.rs
@@ -95,11 +95,7 @@ pub async fn naive_apply(
         &mut req.messages,
         MessageParam::new_with_string(format!("<text>{text}</text>"), MessageRole::User),
     );
-    let mut schema = serde_json::json! {{}};
-    schema["type"] = "object".into();
-    schema["required"] = serde_json::Value::Array(vec![]);
-    schema["properties"] = properties;
-    configure_baseline_structured_output(&mut req, schema);
+    configure_baseline_structured_output(&mut req, baseline_output_schema(properties));
     let start_time = Instant::now();
     let resp = client.send(req).await?;
 
@@ -112,6 +108,15 @@ pub async fn naive_apply(
     }
 
     extract_baseline_response(&resp.content)
+}
+
+fn baseline_output_schema(properties: serde_json::Value) -> serde_json::Value {
+    let mut schema = serde_json::json! {{}};
+    schema["type"] = "object".into();
+    schema["required"] = serde_json::Value::Array(vec![]);
+    schema["properties"] = properties;
+    schema["additionalProperties"] = false.into();
+    schema
 }
 
 fn configure_baseline_structured_output(req: &mut MessageCreateParams, schema: serde_json::Value) {
@@ -475,6 +480,16 @@ mod tests {
         let err = extract_baseline_response(&content).unwrap_err();
 
         assert!(format!("{err:?}").contains("Expected exactly 1 JSON text block"));
+    }
+
+    #[test]
+    fn baseline_output_schema_rejects_additional_properties() {
+        let schema = baseline_output_schema(serde_json::json!({
+            "field": { "type": "string" }
+        }));
+
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["additionalProperties"], false);
     }
 
     #[test]

--- a/src/bin/policyai-regressions-to-examples.rs
+++ b/src/bin/policyai-regressions-to-examples.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::io::{self, BufRead};
 
 use serde_json::Value;
@@ -15,26 +16,83 @@ fn main() {
         let regression: Value = serde_json::from_str(&line)
             .unwrap_or_else(|e| panic!("Failed to parse JSON on line {}: {}", line_num + 1, e));
 
-        let rules_content = regression["report"]["messages"][0]["content"]
-            .as_str()
-            .unwrap_or("");
-        let text = regression["input"]["text"].as_str().unwrap_or("");
-        let ir = &regression["report"]["ir"];
+        print!("{}", example_for_regression(&regression));
+    }
+}
 
-        let output = if ir.is_null() {
-            "{}".to_string()
-        } else {
-            serde_json::to_string_pretty(ir).unwrap()
-        };
+fn example_for_regression(regression: &Value) -> String {
+    let rules_content = regression["report"]["messages"][0]["content"]
+        .as_str()
+        .unwrap_or("");
+    let text = regression["input"]["text"].as_str().unwrap_or("");
+    let expected = &regression["input"]["expected"];
+    let output = if expected.is_null() {
+        "{}".to_string()
+    } else {
+        serde_json::to_string_pretty(expected).unwrap()
+    };
 
-        println!("<example>");
-        println!("<input>");
-        print!("{}", rules_content);
-        println!("<text>{}</text>", text);
-        println!("</input>");
-        println!("<output>");
-        println!("{}", output);
-        println!("</output>");
-        println!("</example>");
+    let mut example = String::new();
+    writeln!(&mut example, "<example>").unwrap();
+    writeln!(&mut example, "<input>").unwrap();
+    write!(&mut example, "{rules_content}").unwrap();
+    writeln!(&mut example, "<text>{text}</text>").unwrap();
+    writeln!(&mut example, "</input>").unwrap();
+    writeln!(&mut example, "<output>").unwrap();
+    writeln!(&mut example, "{output}").unwrap();
+    writeln!(&mut example, "</output>").unwrap();
+    writeln!(&mut example, "</example>").unwrap();
+    example
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn example_output_uses_expected_instead_of_report_ir() {
+        let regression = serde_json::json!({
+            "input": {
+                "text": "example text",
+                "expected": {
+                    "field": "expected value"
+                }
+            },
+            "report": {
+                "messages": [
+                    {
+                        "content": "rules\n"
+                    }
+                ],
+                "ir": {
+                    "field": "bad value"
+                }
+            }
+        });
+
+        let example = example_for_regression(&regression);
+
+        assert!(example.contains("\"field\": \"expected value\""));
+        assert!(!example.contains("\"field\": \"bad value\""));
+    }
+
+    #[test]
+    fn example_output_defaults_to_empty_object_without_expected() {
+        let regression = serde_json::json!({
+            "input": {
+                "text": "example text"
+            },
+            "report": {
+                "messages": [
+                    {
+                        "content": "rules\n"
+                    }
+                ]
+            }
+        });
+
+        let example = example_for_regression(&regression);
+
+        assert!(example.contains("<output>\n{}\n</output>"));
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -11,6 +11,94 @@ use claudius::{
 
 use crate::{Policy, Report, Usage};
 
+/// Command-line wrapper for [`ThinkingConfig`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ThinkingArg(pub ThinkingConfig);
+
+impl Eq for ThinkingArg {}
+
+impl std::str::FromStr for ThinkingArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "adaptive" => Ok(Self(ThinkingConfig::adaptive())),
+            "disabled" | "none" | "off" => Ok(Self(ThinkingConfig::disabled())),
+            value => value
+                .parse::<u32>()
+                .map(|budget| Self(ThinkingConfig::enabled(budget)))
+                .map_err(|_| {
+                    format!("expected thinking to be adaptive, disabled, or a token budget; got {value:?}")
+                }),
+        }
+    }
+}
+
+impl std::fmt::Display for ThinkingArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0 == ThinkingConfig::adaptive() {
+            write!(f, "adaptive")
+        } else if self.0 == ThinkingConfig::disabled() {
+            write!(f, "disabled")
+        } else {
+            write!(f, "{}", self.0.num_tokens())
+        }
+    }
+}
+
+impl From<ThinkingArg> for ThinkingConfig {
+    fn from(value: ThinkingArg) -> Self {
+        value.0
+    }
+}
+
+/// Command-line wrapper for [`Effort`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EffortArg(pub Effort);
+
+impl std::str::FromStr for EffortArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "low" => Ok(Self(Effort::Low)),
+            "medium" => Ok(Self(Effort::Medium)),
+            "high" => Ok(Self(Effort::High)),
+            _ => Err(format!(
+                "expected effort to be one of low, medium, high; got {value:?}"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for EffortArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Effort::Low => write!(f, "low"),
+            Effort::Medium => write!(f, "medium"),
+            Effort::High => write!(f, "high"),
+        }
+    }
+}
+
+impl From<EffortArg> for Effort {
+    fn from(value: EffortArg) -> Self {
+        value.0
+    }
+}
+
+/// Build the output configuration that carries adaptive thinking effort.
+pub fn output_config_for_thinking(
+    thinking: Option<ThinkingConfig>,
+    effort: Option<Effort>,
+) -> Option<OutputConfig> {
+    if matches!(thinking, Some(ThinkingConfig::Adaptive)) {
+        effort.map(|effort| OutputConfig::new().with_effort(effort))
+    } else {
+        None
+    }
+}
+
 /// A semantic injection with multiple candidate injections and their rationales.
 ///
 /// This structure represents test data for evaluating semantic injections against text.
@@ -52,6 +140,9 @@ pub struct SemanticInjection {
 /// * `k` - Minimum number of successes required
 /// * `n` - Maximum number of attempts to make
 /// * `model` - The model to use for policy applicability checks
+/// * `max_tokens` - The maximum output token budget for each check
+/// * `thinking` - Thinking configuration for each check
+/// * `effort` - Adaptive thinking effort, used when `thinking` is adaptive
 ///
 /// # Returns
 ///
@@ -65,7 +156,7 @@ pub struct SemanticInjection {
 /// # Examples
 ///
 /// ```no_run
-/// use claudius::Anthropic;
+/// use claudius::{Anthropic, Effort, ThinkingConfig};
 /// use policyai::{data::policy_applies, DEFAULT_MODEL};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -76,7 +167,10 @@ pub struct SemanticInjection {
 ///     "If text indicates urgency, mark as high priority",
 ///     3,  // Need 3 successes
 ///     5,  // Out of 5 attempts
-///     DEFAULT_MODEL
+///     DEFAULT_MODEL,
+///     1030,
+///     Some(ThinkingConfig::adaptive()),
+///     Some(Effort::Medium)
 /// ).await?;
 /// # Ok(())
 /// # }
@@ -88,8 +182,23 @@ pub async fn policy_applies(
     k: usize,
     n: usize,
     model: Model,
+    max_tokens: u32,
+    thinking: Option<ThinkingConfig>,
+    effort: Option<Effort>,
 ) -> Result<bool, claudius::Error> {
-    Ok(apply_policy_fractional(client, text, semantic_injection, k, n, model).await? >= k)
+    Ok(apply_policy_fractional(
+        client,
+        text,
+        semantic_injection,
+        k,
+        n,
+        model,
+        max_tokens,
+        thinking,
+        effort,
+    )
+    .await?
+        >= k)
 }
 
 /// Determine if a policy does NOT apply to given text with statistical confidence.
@@ -106,6 +215,9 @@ pub async fn policy_applies(
 /// * `k` - Minimum number of successes that would indicate the policy applies
 /// * `n` - Maximum number of attempts to make
 /// * `model` - The model to use for policy applicability checks
+/// * `max_tokens` - The maximum output token budget for each check
+/// * `thinking` - Thinking configuration for each check
+/// * `effort` - Adaptive thinking effort, used when `thinking` is adaptive
 ///
 /// # Returns
 ///
@@ -119,7 +231,7 @@ pub async fn policy_applies(
 /// # Examples
 ///
 /// ```no_run
-/// use claudius::Anthropic;
+/// use claudius::{Anthropic, Effort, ThinkingConfig};
 /// use policyai::{data::policy_does_not_apply, DEFAULT_MODEL};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -130,7 +242,10 @@ pub async fn policy_applies(
 ///     "If text indicates urgency, mark as high priority",
 ///     3,  // Would need 3 successes to apply
 ///     5,  // Out of 5 attempts
-///     DEFAULT_MODEL
+///     DEFAULT_MODEL,
+///     1030,
+///     Some(ThinkingConfig::adaptive()),
+///     Some(Effort::Medium)
 /// ).await?;
 /// # Ok(())
 /// # }
@@ -142,11 +257,23 @@ pub async fn policy_does_not_apply(
     k: usize,
     n: usize,
     model: Model,
+    max_tokens: u32,
+    thinking: Option<ThinkingConfig>,
+    effort: Option<Effort>,
 ) -> Result<bool, claudius::Error> {
-    Ok(
-        apply_policy_fractional(client, text, semantic_injection, k, n, model).await?
-            <= n.saturating_sub(k),
+    Ok(apply_policy_fractional(
+        client,
+        text,
+        semantic_injection,
+        k,
+        n,
+        model,
+        max_tokens,
+        thinking,
+        effort,
     )
+    .await?
+        <= n.saturating_sub(k))
 }
 
 async fn apply_policy_fractional(
@@ -156,6 +283,9 @@ async fn apply_policy_fractional(
     k: usize,
     n: usize,
     model: Model,
+    max_tokens: u32,
+    thinking: Option<ThinkingConfig>,
+    effort: Option<Effort>,
 ) -> Result<usize, claudius::Error> {
     let mut success = 0;
     let mut total = 0;
@@ -178,7 +308,7 @@ Output just this one-word answer
 "#
         .to_string();
         let req = MessageCreateParams {
-            max_tokens: 1030,
+            max_tokens,
             model: model.clone(),
             cache_control: None,
             system: Some(SystemPrompt::from_blocks(vec![TextBlock {
@@ -202,10 +332,10 @@ Output just this one-word answer
                 role: MessageRole::User,
             }],
             stop_sequences: Some(vec!["yes".to_string(), "no".to_string()]),
-            thinking: Some(ThinkingConfig::adaptive()),
+            thinking,
             stream: false,
             metadata: None,
-            output_config: Some(OutputConfig::new().with_effort(Effort::Medium)),
+            output_config: output_config_for_thinking(thinking, effort),
             output_format: None,
             temperature: None,
             tools: None,

--- a/src/data.rs
+++ b/src/data.rs
@@ -331,7 +331,7 @@ Output just this one-word answer
                 ]),
                 role: MessageRole::User,
             }],
-            stop_sequences: Some(vec!["yes".to_string(), "no".to_string()]),
+            stop_sequences: None,
             thinking,
             stream: false,
             metadata: None,

--- a/src/data.rs
+++ b/src/data.rs
@@ -175,6 +175,7 @@ pub struct SemanticInjection {
 /// # Ok(())
 /// # }
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub async fn policy_applies(
     client: &Anthropic,
     text: &str,
@@ -250,6 +251,7 @@ pub async fn policy_applies(
 /// # Ok(())
 /// # }
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub async fn policy_does_not_apply(
     client: &Anthropic,
     text: &str,
@@ -276,6 +278,7 @@ pub async fn policy_does_not_apply(
         <= n.saturating_sub(k))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn apply_policy_fractional(
     client: &Anthropic,
     text: &str,
@@ -345,11 +348,8 @@ Output just this one-word answer
             betas: None,
         };
         let resp = client.send(req).await?;
-        match policy_applies_answer(resp.stop_sequence.as_deref(), &resp.content)? {
-            true => {
-                success += 1;
-            }
-            false => {}
+        if policy_applies_answer(resp.stop_sequence.as_deref(), &resp.content)? {
+            success += 1;
         }
     }
     Ok(success)

--- a/src/data.rs
+++ b/src/data.rs
@@ -6,8 +6,7 @@
 
 use claudius::{
     Anthropic, CacheControlEphemeral, ContentBlock, Effort, MessageCreateParams, MessageParam,
-    MessageParamContent, MessageRole, Model, OutputConfig, StopReason, SystemPrompt, TextBlock,
-    ThinkingConfig,
+    MessageParamContent, MessageRole, Model, OutputConfig, SystemPrompt, TextBlock, ThinkingConfig,
 };
 
 use crate::{Policy, Report, Usage};
@@ -216,29 +215,50 @@ Output just this one-word answer
             betas: None,
         };
         let resp = client.send(req).await?;
-        if !matches!(resp.stop_reason, Some(StopReason::StopSequence)) {
-            return Err(claudius::Error::unknown(
-                "did not get a stop sequence".to_string(),
-            ));
-        }
-        match resp.stop_sequence.as_deref() {
-            Some("yes") => {
+        match policy_applies_answer(resp.stop_sequence.as_deref(), &resp.content)? {
+            true => {
                 success += 1;
             }
-            Some("no") => {}
-            Some(_) => {
-                return Err(claudius::Error::unknown(
-                    "expected yes/no stop sequence".to_string(),
-                ));
-            }
-            None => {
-                return Err(claudius::Error::unknown(
-                    "expected stop sequence".to_string(),
-                ));
-            }
+            false => {}
         }
     }
     Ok(success)
+}
+
+fn policy_applies_answer(
+    stop_sequence: Option<&str>,
+    content: &[ContentBlock],
+) -> Result<bool, claudius::Error> {
+    match stop_sequence {
+        Some("yes") => return Ok(true),
+        Some("no") => return Ok(false),
+        Some(other) => {
+            return Err(claudius::Error::unknown(format!(
+                "expected yes/no stop sequence, got {other:?}"
+            )));
+        }
+        None => {}
+    }
+
+    let answer = content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let first_word = answer
+        .split(|ch: char| !ch.is_ascii_alphabetic())
+        .find(|word| !word.is_empty())
+        .map(str::to_ascii_lowercase);
+    match first_word.as_deref() {
+        Some("yes") => Ok(true),
+        Some("no") => Ok(false),
+        _ => Err(claudius::Error::unknown(format!(
+            "expected yes/no answer, got {answer:?}"
+        ))),
+    }
 }
 
 /// A semantic injection test case with positive and negative examples.

--- a/src/data.rs
+++ b/src/data.rs
@@ -310,58 +310,108 @@ Say, "no" to indicate the policy does not apply.
 Output just this one-word answer
 "#
         .to_string();
-        let req = MessageCreateParams {
+        let req = policy_application_request(
+            &system,
+            text,
+            semantic_injection,
+            model.clone(),
             max_tokens,
-            model: model.clone(),
-            cache_control: None,
-            system: Some(SystemPrompt::from_blocks(vec![TextBlock {
-                text: system.to_string(),
-                cache_control: Some(CacheControlEphemeral::new()),
-                citations: None,
-            }])),
-            messages: vec![MessageParam {
-                content: MessageParamContent::Array(vec![
-                    ContentBlock::Text(TextBlock {
-                        text: format!("<policy>{semantic_injection}</policy>"),
-                        cache_control: None,
-                        citations: None,
-                    }),
-                    ContentBlock::Text(TextBlock {
-                        text: format!("<text>{text}</text>"),
-                        cache_control: None,
-                        citations: None,
-                    }),
-                ]),
-                role: MessageRole::User,
-            }],
-            stop_sequences: None,
             thinking,
-            stream: false,
-            metadata: None,
-            output_config: output_config_for_thinking(thinking, effort),
-            output_format: None,
-            temperature: None,
-            tools: None,
-            tool_choice: None,
-            top_p: None,
-            top_k: None,
-            betas: None,
-        };
+            effort,
+        );
         let resp = client.send(req).await?;
-        if policy_applies_answer(resp.stop_sequence.as_deref(), &resp.content)? {
+        let answer = match policy_applies_answer(resp.stop_sequence.as_deref(), &resp.content)? {
+            Some(answer) => answer,
+            None if thinking.is_some_and(|thinking| thinking != ThinkingConfig::Disabled) => {
+                let req = policy_application_request(
+                    &system,
+                    text,
+                    semantic_injection,
+                    model.clone(),
+                    max_tokens,
+                    None,
+                    None,
+                );
+                let resp = client.send(req).await?;
+                policy_applies_answer(resp.stop_sequence.as_deref(), &resp.content)?.ok_or_else(
+                    || {
+                        claudius::Error::unknown(
+                            "expected yes/no answer after retry without thinking, got empty response"
+                                .to_string(),
+                        )
+                    },
+                )?
+            }
+            None => {
+                return Err(claudius::Error::unknown(
+                    "expected yes/no answer, got empty response".to_string(),
+                ));
+            }
+        };
+        if answer {
             success += 1;
         }
     }
     Ok(success)
 }
 
+fn policy_application_request(
+    system: &str,
+    text: &str,
+    semantic_injection: &str,
+    model: Model,
+    max_tokens: u32,
+    thinking: Option<ThinkingConfig>,
+    effort: Option<Effort>,
+) -> MessageCreateParams {
+    MessageCreateParams {
+        max_tokens,
+        model,
+        cache_control: None,
+        system: Some(SystemPrompt::from_blocks(vec![TextBlock {
+            text: system.to_string(),
+            cache_control: Some(CacheControlEphemeral::new()),
+            citations: None,
+        }])),
+        messages: vec![MessageParam {
+            content: MessageParamContent::Array(vec![
+                ContentBlock::Text(TextBlock {
+                    text: format!("<policy>{semantic_injection}</policy>"),
+                    cache_control: None,
+                    citations: None,
+                }),
+                ContentBlock::Text(TextBlock {
+                    text: format!("<text>{text}</text>"),
+                    cache_control: None,
+                    citations: None,
+                }),
+            ]),
+            role: MessageRole::User,
+        }],
+        // Do not use "yes" or "no" as stop sequences here. Stop sequences can match inside
+        // thinking blocks before the model has emitted a visible final answer.
+        stop_sequences: None,
+        thinking,
+        stream: false,
+        metadata: None,
+        output_config: output_config_for_thinking(thinking, effort),
+        output_format: None,
+        temperature: None,
+        tools: None,
+        tool_choice: None,
+        top_p: None,
+        top_k: None,
+        betas: None,
+    }
+}
+
 fn policy_applies_answer(
     stop_sequence: Option<&str>,
     content: &[ContentBlock],
-) -> Result<bool, claudius::Error> {
+) -> Result<Option<bool>, claudius::Error> {
     match stop_sequence {
-        Some("yes") => return Ok(true),
-        Some("no") => return Ok(false),
+        Some("yes") => return Ok(Some(true)),
+        Some("no") => return Ok(Some(false)),
         Some(other) => {
             return Err(claudius::Error::unknown(format!(
                 "expected yes/no stop sequence, got {other:?}"
@@ -378,13 +428,16 @@ fn policy_applies_answer(
         })
         .collect::<Vec<_>>()
         .join("\n");
+    if answer.trim().is_empty() {
+        return Ok(None);
+    }
     let first_word = answer
         .split(|ch: char| !ch.is_ascii_alphabetic())
         .find(|word| !word.is_empty())
         .map(str::to_ascii_lowercase);
     match first_word.as_deref() {
-        Some("yes") => Ok(true),
-        Some("no") => Ok(false),
+        Some("yes") => Ok(Some(true)),
+        Some("no") => Ok(Some(false)),
         _ => Err(claudius::Error::unknown(format!(
             "expected yes/no answer, got {answer:?}"
         ))),
@@ -648,6 +701,24 @@ mod tests {
         assert_eq!(injection.injections, deserialized.injections);
         assert_eq!(injection.rationales, deserialized.rationales);
         assert_eq!(injection.text, deserialized.text);
+    }
+
+    #[test]
+    fn policy_applies_answer_reads_visible_text() {
+        let content = vec![claudius::ContentBlock::Text(claudius::TextBlock::new(
+            "yes",
+        ))];
+
+        assert_eq!(policy_applies_answer(None, &content).unwrap(), Some(true));
+    }
+
+    #[test]
+    fn policy_applies_answer_ignores_thinking_for_empty_answer() {
+        let content = vec![claudius::ContentBlock::Thinking(
+            claudius::ThinkingBlock::new("yes, this applies", "signature"),
+        )];
+
+        assert_eq!(policy_applies_answer(None, &content).unwrap(), None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod compiler;
 mod errors;
 mod field;
 mod manager;
+mod mask_names;
 mod masks;
 mod on_conflict;
 mod parser;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -16,11 +16,11 @@ use crate::{ApplyError, Policy, PolicyError, Report, ReportBuilder, Usage};
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum InferenceConfig {
     /// Use the `output_json` tool without strict structured-output validation.
-    #[default]
     ToolUse,
     /// Use the `output_json` tool with `strict: true`.
     StrictToolUse,
     /// Use [`OutputFormat::JsonSchema`] instead of tool use.
+    #[default]
     OutputFormatJsonSchema,
 }
 
@@ -203,19 +203,22 @@ impl Manager {
                 usage.increment_iterations();
             }
             let extracted = extract_ir(&resp.content, inference_config)?;
-            let ir = extracted.ir;
-            let Some(reportedly_matched) = ir.get("__rule_numbers__").cloned() else {
-                continue;
-            };
-            let Some(mut reportedly_matched): Option<Vec<usize>> =
-                serde_json::from_value(reportedly_matched).ok()
-            else {
-                continue;
-            };
-            let report = report.clone().consume_ir(ir.clone())?;
+            let mut ir = extracted.ir;
+            let mut report = report.clone().consume_ir(ir.clone())?;
             let mut empirically_matched = report.rules_matched.clone();
             empirically_matched.sort();
             empirically_matched.dedup();
+            let Some(mut reportedly_matched): Option<Vec<usize>> = ir
+                .get("__rule_numbers__")
+                .cloned()
+                .and_then(|value| serde_json::from_value(value).ok())
+            else {
+                normalize_reported_rule_numbers(&mut report, &mut ir, &empirically_matched);
+                if let Some(usage) = &mut usage {
+                    usage.set_wall_clock_time(start_time.elapsed());
+                }
+                return Ok(report);
+            };
             reportedly_matched.sort();
             reportedly_matched.dedup();
             if *empirically_matched == reportedly_matched {
@@ -235,6 +238,13 @@ impl Manager {
                 .filter(|x| !empirically_matched.iter().any(|y| **x == *y))
                 .cloned()
                 .collect::<Vec<_>>();
+            if reported_but_not_empirical.is_empty() {
+                normalize_reported_rule_numbers(&mut report, &mut ir, &empirically_matched);
+                if let Some(usage) = &mut usage {
+                    usage.set_wall_clock_time(start_time.elapsed());
+                }
+                return Ok(report);
+            }
             let mut content =
                 "<instruction>The reported rule numbers do not match the fields that were output.  Re-evaluate your output to resolve the following inconsistencies.</instruction>"
                     .to_string();
@@ -399,11 +409,13 @@ impl Manager {
     }
 }
 
+#[derive(Debug)]
 struct ExtractedIr {
     ir: serde_json::Value,
     feedback: FeedbackTarget,
 }
 
+#[derive(Debug)]
 enum FeedbackTarget {
     Tool { tool_use_id: String },
     Text,
@@ -414,20 +426,37 @@ fn extract_ir(
     content: &[ContentBlock],
     inference_config: InferenceConfig,
 ) -> Result<ExtractedIr, ApplyError> {
-    if content.len() != 1 {
-        return Err(ApplyError::invalid_response(
-            format!("Expected exactly 1 content block, got {}", content.len()),
-            "Check that the LLM is configured correctly for the selected inference config",
-        ));
-    }
     match inference_config {
         InferenceConfig::ToolUse | InferenceConfig::StrictToolUse => {
-            let ContentBlock::ToolUse(t) = &content[0] else {
+            let mut output_json_blocks = 0;
+            let mut other_blocks = 0;
+            let mut tool_use = None;
+            for block in content {
+                match block {
+                    ContentBlock::Thinking(_) | ContentBlock::RedactedThinking(_) => {}
+                    ContentBlock::ToolUse(t) if t.name == "output_json" => {
+                        output_json_blocks += 1;
+                        tool_use = Some(t);
+                    }
+                    _ => other_blocks += 1,
+                }
+            }
+            let Some(t) = tool_use else {
                 return Err(ApplyError::invalid_response(
-                    "Expected ToolUse content block",
+                    format!(
+                        "Expected exactly 1 output_json tool_use block after ignoring thinking blocks, got {output_json_blocks} output_json blocks and {other_blocks} other blocks"
+                    ),
                     "The LLM should be using the output_json tool to provide structured output",
                 ));
             };
+            if output_json_blocks != 1 || other_blocks != 0 {
+                return Err(ApplyError::invalid_response(
+                    format!(
+                        "Expected exactly 1 output_json tool_use block after ignoring thinking blocks, got {output_json_blocks} output_json blocks and {other_blocks} other blocks"
+                    ),
+                    "The LLM should be using the output_json tool to provide structured output",
+                ));
+            }
             Ok(ExtractedIr {
                 ir: t.input.clone(),
                 feedback: FeedbackTarget::Tool {
@@ -436,13 +465,36 @@ fn extract_ir(
             })
         }
         InferenceConfig::OutputFormatJsonSchema => {
-            let ContentBlock::Text(t) = &content[0] else {
+            let mut json_text_blocks = 0;
+            let mut other_blocks = 0;
+            let mut text = None;
+            for block in content {
+                match block {
+                    ContentBlock::Thinking(_) | ContentBlock::RedactedThinking(_) => {}
+                    ContentBlock::Text(t) if !t.text.trim().is_empty() => {
+                        json_text_blocks += 1;
+                        text = Some(t.text.trim());
+                    }
+                    _ => other_blocks += 1,
+                }
+            }
+            let Some(text) = text else {
                 return Err(ApplyError::invalid_response(
-                    "Expected Text content block",
+                    format!(
+                        "Expected exactly 1 JSON text block after ignoring thinking blocks, got {json_text_blocks} JSON text blocks and {other_blocks} other blocks"
+                    ),
                     "The LLM should return JSON text when OutputFormatJsonSchema is selected",
                 ));
             };
-            let ir = serde_json::from_str(t.text.trim()).map_err(|err| {
+            if json_text_blocks != 1 || other_blocks != 0 {
+                return Err(ApplyError::invalid_response(
+                    format!(
+                        "Expected exactly 1 JSON text block after ignoring thinking blocks, got {json_text_blocks} JSON text blocks and {other_blocks} other blocks"
+                    ),
+                    "The LLM should return JSON text when OutputFormatJsonSchema is selected",
+                ));
+            }
+            let ir = serde_json::from_str(text).map_err(|err| {
                 ApplyError::invalid_response(
                     format!("Could not parse JSON response: {err}"),
                     "Check that the model response is valid JSON for the configured schema",
@@ -454,6 +506,20 @@ fn extract_ir(
             })
         }
     }
+}
+
+fn normalize_reported_rule_numbers(
+    report: &mut Report,
+    ir: &mut serde_json::Value,
+    empirically_matched: &[usize],
+) {
+    if let Some(object) = ir.as_object_mut() {
+        object.insert(
+            "__rule_numbers__".to_string(),
+            serde_json::json!(empirically_matched),
+        );
+    }
+    report.ir = Some(ir.clone());
 }
 
 fn configure_structured_output(
@@ -476,7 +542,7 @@ fn configure_structured_output(
     } else {
         req.tool_choice = None;
         req.tools = None;
-        req.output_format = Some(OutputFormat::json_schema(report.schema()));
+        set_json_schema_output(req, report.schema());
     }
 }
 
@@ -490,11 +556,20 @@ fn clear_output_format_config(req: &mut MessageCreateParams) {
     }
 }
 
+fn set_json_schema_output(req: &mut MessageCreateParams, schema: serde_json::Value) {
+    if let Some(output_config) = &mut req.output_config {
+        req.output_format = None;
+        output_config.format = Some(OutputFormat::json_schema(schema));
+    } else {
+        req.output_format = Some(OutputFormat::json_schema(schema));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{Field, PolicyType};
-    use claudius::SystemPrompt;
+    use claudius::{SystemPrompt, ThinkingBlock, ToolUseBlock};
 
     fn create_test_policy_type() -> PolicyType {
         PolicyType {
@@ -532,7 +607,10 @@ mod tests {
         let manager = Manager::default();
         assert!(manager.is_empty());
         assert_eq!(manager.len(), 0);
-        assert_eq!(manager.inference_config(), InferenceConfig::ToolUse);
+        assert_eq!(
+            manager.inference_config(),
+            InferenceConfig::OutputFormatJsonSchema
+        );
     }
 
     #[test]
@@ -624,8 +702,10 @@ mod tests {
         let (_report, req) = result.unwrap();
         assert!(!req.messages.is_empty());
         assert!(req.system.is_some());
-        assert_eq!(req.tool_choice, Some(ToolChoice::tool("output_json")));
-        assert!(!req.requires_structured_outputs_beta());
+        assert!(req.tool_choice.is_none());
+        assert!(req.tools.is_none());
+        assert!(req.output_format.is_some());
+        assert!(req.requires_structured_outputs_beta());
     }
 
     #[tokio::test]
@@ -713,7 +793,9 @@ mod tests {
         let (report, req) = result.unwrap();
         assert!(!req.messages.is_empty()); // At least one message
         assert!(req.system.is_some());
-        assert!(req.tools.is_some());
+        assert!(req.tool_choice.is_none());
+        assert!(req.tools.is_none());
+        assert!(req.output_format.is_some());
 
         // Verify the schema includes masked fields and special fields
         let schema = report.schema();
@@ -776,7 +858,7 @@ mod tests {
 
         // Verify key parts of the system prompt
         assert!(system_str.contains("Output JSON"));
-        assert!(system_str.contains("if and only if a rule matches"));
+        assert!(system_str.contains("if and only if that rule matches"));
     }
 
     #[test]
@@ -809,5 +891,53 @@ mod tests {
             }
         }
         assert!(found_text, "Request should include the input text");
+    }
+
+    #[test]
+    fn extract_ir_ignores_thinking_blocks_for_tool_use() {
+        let content = vec![
+            ContentBlock::Thinking(ThinkingBlock::new("thinking", "signature")),
+            ContentBlock::ToolUse(ToolUseBlock::new(
+                "tool_123",
+                "output_json",
+                serde_json::json!({"__rule_numbers__": [1]}),
+            )),
+        ];
+
+        let extracted = extract_ir(&content, InferenceConfig::ToolUse).unwrap();
+
+        assert_eq!(extracted.ir, serde_json::json!({"__rule_numbers__": [1]}));
+        match extracted.feedback {
+            FeedbackTarget::Tool { tool_use_id } => assert_eq!(tool_use_id, "tool_123"),
+            FeedbackTarget::Text => panic!("expected tool feedback"),
+        }
+    }
+
+    #[test]
+    fn extract_ir_ignores_thinking_blocks_for_json_schema_output() {
+        let content = vec![
+            ContentBlock::Thinking(ThinkingBlock::new("thinking", "signature")),
+            ContentBlock::Text(TextBlock::new(r#"{"__rule_numbers__":[1]}"#)),
+        ];
+
+        let extracted = extract_ir(&content, InferenceConfig::OutputFormatJsonSchema).unwrap();
+
+        assert_eq!(extracted.ir, serde_json::json!({"__rule_numbers__": [1]}));
+        match extracted.feedback {
+            FeedbackTarget::Text => {}
+            FeedbackTarget::Tool { .. } => panic!("expected text feedback"),
+        }
+    }
+
+    #[test]
+    fn extract_ir_rejects_multiple_json_text_blocks() {
+        let content = vec![
+            ContentBlock::Text(TextBlock::new(r#"{"a":1}"#)),
+            ContentBlock::Text(TextBlock::new(r#"{"b":2}"#)),
+        ];
+
+        let err = extract_ir(&content, InferenceConfig::OutputFormatJsonSchema).unwrap_err();
+
+        assert!(format!("{err:?}").contains("Expected exactly 1 JSON text block"));
     }
 }

--- a/src/mask_names.rs
+++ b/src/mask_names.rs
@@ -1,0 +1,27 @@
+use guacamole::{combinators, Guacamole};
+
+/// Deterministic stream of UUID-shaped mask names.
+#[derive(Clone)]
+pub(crate) struct MaskNameGenerator {
+    guac: Guacamole,
+}
+
+impl MaskNameGenerator {
+    /// Create a generator at the beginning of the guacamole seed-0 stream.
+    pub(crate) fn new() -> Self {
+        Self {
+            guac: Guacamole::new(0),
+        }
+    }
+
+    /// Return the next UUID-shaped value from the deterministic stream.
+    pub(crate) fn next(&mut self) -> String {
+        combinators::uuid(&mut self.guac)
+    }
+}
+
+impl Default for MaskNameGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/policy_type.rs
+++ b/src/policy_type.rs
@@ -2,9 +2,8 @@ use claudius::{
     Anthropic, ContentBlock, Effort, JsonSchema, MessageCreateParams, MessageParam, MessageRole,
     Model, OutputConfig, ThinkingConfig, ToolChoice,
 };
-use uuid::Uuid;
 
-use crate::{parser, Field, ParseError, Policy};
+use crate::{mask_names::MaskNameGenerator, parser, Field, ParseError, Policy};
 
 /// Represents a policy type definition with a name and a set of typed fields.
 ///
@@ -70,54 +69,7 @@ impl PolicyType {
         model: Model,
     ) -> Result<Policy, claudius::Error> {
         let mut schema = serde_json::json! {{}};
-        let mut action_masks = Vec::new();
-        for field in self.fields.iter() {
-            let field_mask = Uuid::new_v4().to_string();
-            let (name, field_schema, enum_values) = match field {
-                Field::Bool {
-                    name,
-                    default: _,
-                    on_conflict: _,
-                } => (name.clone(), bool::json_schema(), Vec::new()),
-                Field::Number {
-                    name,
-                    default: _,
-                    on_conflict: _,
-                } => (name.clone(), f64::json_schema(), Vec::new()),
-                Field::String {
-                    name,
-                    default: _,
-                    on_conflict: _,
-                } => (name.clone(), String::json_schema(), Vec::new()),
-                Field::StringEnum {
-                    name,
-                    values,
-                    default: _,
-                    on_conflict: _,
-                } => {
-                    let enum_values = values
-                        .iter()
-                        .map(|value| (value.clone(), Uuid::new_v4().to_string()))
-                        .collect::<Vec<_>>();
-                    let mut schema = String::json_schema();
-                    schema["enum"] = enum_values
-                        .iter()
-                        .map(|(_, mask)| mask.clone())
-                        .collect::<Vec<_>>()
-                        .into();
-                    (name.clone(), schema, enum_values)
-                }
-                Field::StringArray { name } => {
-                    (name.clone(), Vec::<String>::json_schema(), Vec::new())
-                }
-            };
-            action_masks.push(SemanticActionMask {
-                name,
-                mask: field_mask,
-                enum_values,
-                schema: field_schema,
-            });
-        }
+        let action_masks = self.semantic_action_masks();
         let mut masked_injection = semantic_action_clause(injection).to_string();
         for action_mask in &action_masks {
             masked_injection =
@@ -236,6 +188,59 @@ impl PolicyType {
         })
     }
 
+    fn semantic_action_masks(&self) -> Vec<SemanticActionMask> {
+        let mut mask_names = MaskNameGenerator::new();
+        let mut action_masks = Vec::new();
+        for field in self.fields.iter() {
+            let field_mask = mask_names.next();
+            let (name, field_schema, enum_values) = match field {
+                Field::Bool {
+                    name,
+                    default: _,
+                    on_conflict: _,
+                } => (name.clone(), bool::json_schema(), Vec::new()),
+                Field::Number {
+                    name,
+                    default: _,
+                    on_conflict: _,
+                } => (name.clone(), f64::json_schema(), Vec::new()),
+                Field::String {
+                    name,
+                    default: _,
+                    on_conflict: _,
+                } => (name.clone(), String::json_schema(), Vec::new()),
+                Field::StringEnum {
+                    name,
+                    values,
+                    default: _,
+                    on_conflict: _,
+                } => {
+                    let enum_values = values
+                        .iter()
+                        .map(|value| (value.clone(), mask_names.next()))
+                        .collect::<Vec<_>>();
+                    let mut schema = String::json_schema();
+                    schema["enum"] = enum_values
+                        .iter()
+                        .map(|(_, mask)| mask.clone())
+                        .collect::<Vec<_>>()
+                        .into();
+                    (name.clone(), schema, enum_values)
+                }
+                Field::StringArray { name } => {
+                    (name.clone(), Vec::<String>::json_schema(), Vec::new())
+                }
+            };
+            action_masks.push(SemanticActionMask {
+                name,
+                mask: field_mask,
+                enum_values,
+                schema: field_schema,
+            });
+        }
+        action_masks
+    }
+
     fn sanitize_semantic_action(
         &self,
         injection: &str,
@@ -262,6 +267,7 @@ impl PolicyType {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
 struct SemanticActionMask {
     name: String,
     mask: String,
@@ -510,6 +516,16 @@ mod tests {
         );
 
         assert_eq!(serde_json::json!({"weight": 1.25}), action);
+    }
+
+    #[test]
+    fn semantic_action_masks_are_deterministic() {
+        let policy_type = create_test_policy_type();
+
+        assert_eq!(
+            policy_type.semantic_action_masks(),
+            policy_type.semantic_action_masks()
+        );
     }
 
     #[test]

--- a/src/report_builder.rs
+++ b/src/report_builder.rs
@@ -1,9 +1,8 @@
 use claudius::{push_or_merge_message, JsonSchema, MessageParam, MessageRole};
-use uuid::Uuid;
 
 use crate::{
-    ApplyError, BoolMask, Field, NumberMask, Policy, PolicyError, Report, StringArrayMask,
-    StringEnumMask, StringMask,
+    mask_names::MaskNameGenerator, ApplyError, BoolMask, Field, NumberMask, Policy, PolicyError,
+    Report, StringArrayMask, StringEnumMask, StringMask,
 };
 
 /// Builder for constructing Reports from policy definitions.
@@ -21,6 +20,7 @@ pub struct ReportBuilder {
     string_array_masks: Vec<StringArrayMask>,
     string_enum_masks: Vec<StringEnumMask>,
     masks_by_index: Vec<Vec<String>>,
+    mask_names: MaskNameGenerator,
     default_return: serde_json::Value,
     messages: Vec<MessageParam>,
     policy_index: usize,
@@ -71,6 +71,7 @@ impl ReportBuilder {
         // increment policy_index at the end when we "commit".
         self.mask_index += 1;
         let mut content = policy.prompt.clone();
+        let mut mask_names = self.mask_names.clone();
 
         // Collect all changes first before applying them
         let mut new_bool_masks = Vec::new();
@@ -95,7 +96,7 @@ impl ReportBuilder {
                     let serde_json::Value::Bool(_) = value else {
                         return Err(PolicyError::expected_bool(name.clone(), value));
                     };
-                    let mask = Uuid::new_v4().to_string();
+                    let mask = mask_names.next();
                     new_masks.push(mask.clone());
                     new_bool_masks.push(BoolMask::new(
                         self.policy_index,
@@ -118,7 +119,7 @@ impl ReportBuilder {
                         serde_json::Value::Null => None,
                         _ => return Err(PolicyError::expected_number(name.clone(), value)),
                     };
-                    let mask = Uuid::new_v4().to_string();
+                    let mask = mask_names.next();
                     new_masks.push(mask.clone());
                     new_number_masks.push(NumberMask::new(
                         self.policy_index,
@@ -144,7 +145,7 @@ impl ReportBuilder {
                         serde_json::Value::Null => None,
                         _ => return Err(PolicyError::expected_string(name.clone(), value)),
                     };
-                    let mask = Uuid::new_v4().to_string();
+                    let mask = mask_names.next();
                     new_masks.push(mask.clone());
                     new_string_masks.push(StringMask::new(
                         self.policy_index,
@@ -172,7 +173,7 @@ impl ReportBuilder {
                             return Err(PolicyError::expected_string(name.clone(), v));
                         }
                     }
-                    let mask = Uuid::new_v4().to_string();
+                    let mask = mask_names.next();
                     new_masks.push(mask.clone());
                     new_string_array_masks.push(StringArrayMask::new(
                         self.policy_index,
@@ -198,7 +199,7 @@ impl ReportBuilder {
                             Some(found_value.clone())
                         }
                     };
-                    let mask = Uuid::new_v4().to_string();
+                    let mask = mask_names.next();
                     new_masks.push(mask.clone());
                     new_string_enum_masks.push(StringEnumMask::new(
                         self.policy_index,
@@ -240,6 +241,7 @@ impl ReportBuilder {
         self.string_array_masks.extend(new_string_array_masks);
         self.string_enum_masks.extend(new_string_enum_masks);
         self.masks_by_index.push(new_masks);
+        self.mask_names = mask_names;
 
         self.policy_index += 1;
         Ok(())
@@ -367,6 +369,7 @@ impl Default for ReportBuilder {
             string_array_masks: vec![],
             string_enum_masks: vec![],
             masks_by_index: vec![],
+            mask_names: MaskNameGenerator::new(),
             default_return: serde_json::json! {{}},
             messages: vec![],
             policy_index: 1,
@@ -385,6 +388,7 @@ impl Default for ReportBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{OnConflict, PolicyType};
 
     #[test]
     fn schema_rejects_additional_properties() {
@@ -392,5 +396,62 @@ mod tests {
 
         assert_eq!(schema["type"], "object");
         assert_eq!(schema["additionalProperties"], false);
+    }
+
+    fn test_policy(action: serde_json::Value) -> Policy {
+        Policy {
+            r#type: PolicyType {
+                name: "TestPolicy".to_string(),
+                fields: vec![
+                    Field::Bool {
+                        name: "enabled".to_string(),
+                        default: Some(false),
+                        on_conflict: OnConflict::Agreement,
+                    },
+                    Field::Number {
+                        name: "score".to_string(),
+                        default: Some(crate::t64(0.0)),
+                        on_conflict: OnConflict::LargestValue,
+                    },
+                ],
+            },
+            prompt: r#"Set "enabled" and "score"."#.to_string(),
+            action,
+        }
+    }
+
+    #[test]
+    fn schema_masks_are_deterministic_for_same_policy() {
+        let policy = test_policy(serde_json::json!({
+            "enabled": true,
+            "score": 2.5,
+        }));
+        let mut left = ReportBuilder::default();
+        let mut right = ReportBuilder::default();
+
+        left.add_policy(&policy).unwrap();
+        right.add_policy(&policy).unwrap();
+
+        assert_eq!(left.schema(), right.schema());
+    }
+
+    #[test]
+    fn failed_policy_does_not_advance_mask_stream() {
+        let invalid_policy = test_policy(serde_json::json!({
+            "enabled": true,
+            "score": "not a number",
+        }));
+        let valid_policy = test_policy(serde_json::json!({
+            "enabled": true,
+            "score": 2.5,
+        }));
+        let mut retry_builder = ReportBuilder::default();
+        let mut fresh_builder = ReportBuilder::default();
+
+        assert!(retry_builder.add_policy(&invalid_policy).is_err());
+        retry_builder.add_policy(&valid_policy).unwrap();
+        fresh_builder.add_policy(&valid_policy).unwrap();
+
+        assert_eq!(retry_builder.schema(), fresh_builder.schema());
     }
 }

--- a/src/report_builder.rs
+++ b/src/report_builder.rs
@@ -352,6 +352,7 @@ impl ReportBuilder {
         schema["type"] = "object".into();
         schema["required"] = self.required.clone().into();
         schema["properties"] = self.properties.clone();
+        schema["additionalProperties"] = false.into();
         schema
     }
 }
@@ -378,5 +379,18 @@ impl Default for ReportBuilder {
                 "__justification__": String::json_schema(),
             }},
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_rejects_additional_properties() {
+        let schema = ReportBuilder::default().schema();
+
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["additionalProperties"], false);
     }
 }


### PR DESCRIPTION
Thread a MODEL variable through the Hypermakefile so that data
pipeline artifacts (semantic injections, decidables, test data,
reports, regressions) are keyed by model name. This allows running
the pipeline with different models without clobbering prior results.

- Add MODEL variable (default: claude-opus-4-8)
- Pass --model $(MODEL) to generate-semantic-injections,
  generate-decidables, and policyai-evaluate-policies
- Rename output files to include $(MODEL) in their paths
- Reduce default SEMANTIC_INJECTIONS from 1000 to 10

Co-authored-by: AI
