### PR TITLE
feat(dashboard): add static experiment results viewer

### DIFF
--- a/dashboard/deepseek-v4-flash.json
+++ b/dashboard/deepseek-v4-flash.json
@@ -1,0 +1,66 @@
+{
+  "summary": {
+    "total_reports": 300,
+    "policyai": {
+      "avg_fields_matched": 2.5366666666666666,
+      "total_matched_field_values": 761,
+      "total_wrong_values": 8,
+      "total_missing_fields": 32,
+      "total_missing_field_values": 32,
+      "total_extra_fields": 31,
+      "total_extra_field_values": 31,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.03,
+      "avg_duration_ms": 6296.873333333333
+    },
+    "baseline": {
+      "avg_fields_matched": 2.04,
+      "total_matched_field_values": 612,
+      "total_wrong_values": 2,
+      "total_missing_fields": 58,
+      "total_missing_field_values": 58,
+      "total_extra_fields": 2,
+      "total_extra_field_values": 2,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.14666666666666667,
+      "avg_duration_ms": 4726.503333333333
+    },
+    "comparison": {
+      "fields_matched_improvement": 0.4966666666666666,
+      "speed_ratio": 0.7506111498722646,
+      "error_rate_difference": -0.11666666666666667
+    },
+    "field_match_accuracy": {
+      "expected_vs_control": {
+        "source": "baseline",
+        "confusion_matrix": {
+          "true_positive": 612,
+          "false_positive": 2,
+          "true_negative": 0,
+          "false_negative": 58
+        },
+        "metrics": {
+          "precision": 0.996742671009772,
+          "recall": 0.9134328358208955,
+          "f1_score": 0.9532710280373832,
+          "accuracy": 0.9107142857142857
+        }
+      },
+      "expected_vs_experimental": {
+        "source": "output",
+        "confusion_matrix": {
+          "true_positive": 761,
+          "false_positive": 31,
+          "true_negative": 0,
+          "false_negative": 32
+        },
+        "metrics": {
+          "precision": 0.9608585858585859,
+          "recall": 0.9596469104665826,
+          "f1_score": 0.9602523659305994,
+          "accuracy": 0.9235436893203883
+        }
+      }
+    }
+  }
+}

--- a/dashboard/deepseek-v4-pro.json
+++ b/dashboard/deepseek-v4-pro.json
@@ -1,0 +1,66 @@
+{
+  "summary": {
+    "total_reports": 300,
+    "policyai": {
+      "avg_fields_matched": 2.64,
+      "total_matched_field_values": 792,
+      "total_wrong_values": 1,
+      "total_missing_fields": 1,
+      "total_missing_field_values": 1,
+      "total_extra_fields": 18,
+      "total_extra_field_values": 18,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.0,
+      "avg_duration_ms": 19330.833333333332
+    },
+    "baseline": {
+      "avg_fields_matched": 2.01,
+      "total_matched_field_values": 603,
+      "total_wrong_values": 1,
+      "total_missing_fields": 190,
+      "total_missing_field_values": 190,
+      "total_extra_fields": 1,
+      "total_extra_field_values": 1,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.0,
+      "avg_duration_ms": 15971.236666666666
+    },
+    "comparison": {
+      "fields_matched_improvement": 0.6300000000000003,
+      "speed_ratio": 0.8262052851661853,
+      "error_rate_difference": 0.0
+    },
+    "field_match_accuracy": {
+      "expected_vs_control": {
+        "source": "baseline",
+        "confusion_matrix": {
+          "true_positive": 603,
+          "false_positive": 1,
+          "true_negative": 0,
+          "false_negative": 190
+        },
+        "metrics": {
+          "precision": 0.9983443708609272,
+          "recall": 0.7604035308953342,
+          "f1_score": 0.8632784538296351,
+          "accuracy": 0.7594458438287154
+        }
+      },
+      "expected_vs_experimental": {
+        "source": "output",
+        "confusion_matrix": {
+          "true_positive": 792,
+          "false_positive": 18,
+          "true_negative": 0,
+          "false_negative": 1
+        },
+        "metrics": {
+          "precision": 0.9777777777777777,
+          "recall": 0.9987389659520807,
+          "f1_score": 0.9881472239550843,
+          "accuracy": 0.9765721331689272
+        }
+      }
+    }
+  }
+}

--- a/dashboard/gpt-oss-120b.json
+++ b/dashboard/gpt-oss-120b.json
@@ -1,0 +1,66 @@
+{
+  "summary": {
+    "total_reports": 300,
+    "policyai": {
+      "avg_fields_matched": 2.63,
+      "total_matched_field_values": 789,
+      "total_wrong_values": 2,
+      "total_missing_fields": 4,
+      "total_missing_field_values": 4,
+      "total_extra_fields": 4,
+      "total_extra_field_values": 4,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.0,
+      "avg_duration_ms": 13413.993333333334
+    },
+    "baseline": {
+      "avg_fields_matched": 2.6,
+      "total_matched_field_values": 780,
+      "total_wrong_values": 0,
+      "total_missing_fields": 13,
+      "total_missing_field_values": 13,
+      "total_extra_fields": 0,
+      "total_extra_field_values": 0,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.0,
+      "avg_duration_ms": 5137.66
+    },
+    "comparison": {
+      "fields_matched_improvement": 0.029999999999999805,
+      "speed_ratio": 0.3830074961520283,
+      "error_rate_difference": 0.0
+    },
+    "field_match_accuracy": {
+      "expected_vs_control": {
+        "source": "baseline",
+        "confusion_matrix": {
+          "true_positive": 780,
+          "false_positive": 0,
+          "true_negative": 0,
+          "false_negative": 13
+        },
+        "metrics": {
+          "precision": 1.0,
+          "recall": 0.9836065573770492,
+          "f1_score": 0.9917355371900827,
+          "accuracy": 0.9836065573770492
+        }
+      },
+      "expected_vs_experimental": {
+        "source": "output",
+        "confusion_matrix": {
+          "true_positive": 789,
+          "false_positive": 4,
+          "true_negative": 0,
+          "false_negative": 4
+        },
+        "metrics": {
+          "precision": 0.9949558638083228,
+          "recall": 0.9949558638083228,
+          "f1_score": 0.9949558638083228,
+          "accuracy": 0.9899623588456713
+        }
+      }
+    }
+  }
+}

--- a/dashboard/gpt-oss-20b.json
+++ b/dashboard/gpt-oss-20b.json
@@ -1,0 +1,66 @@
+{
+  "summary": {
+    "total_reports": 300,
+    "policyai": {
+      "avg_fields_matched": 2.6066666666666665,
+      "total_matched_field_values": 782,
+      "total_wrong_values": 0,
+      "total_missing_fields": 11,
+      "total_missing_field_values": 11,
+      "total_extra_fields": 0,
+      "total_extra_field_values": 0,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.006666666666666667,
+      "avg_duration_ms": 23934.566666666666
+    },
+    "baseline": {
+      "avg_fields_matched": 2.1966666666666668,
+      "total_matched_field_values": 659,
+      "total_wrong_values": 13,
+      "total_missing_fields": 100,
+      "total_missing_field_values": 100,
+      "total_extra_fields": 13,
+      "total_extra_field_values": 13,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.043333333333333335,
+      "avg_duration_ms": 29720.306666666667
+    },
+    "comparison": {
+      "fields_matched_improvement": 0.4099999999999997,
+      "speed_ratio": 1.241731554223529,
+      "error_rate_difference": -0.03666666666666667
+    },
+    "field_match_accuracy": {
+      "expected_vs_control": {
+        "source": "baseline",
+        "confusion_matrix": {
+          "true_positive": 659,
+          "false_positive": 13,
+          "true_negative": 0,
+          "false_negative": 100
+        },
+        "metrics": {
+          "precision": 0.9806547619047619,
+          "recall": 0.8682476943346509,
+          "f1_score": 0.9210342417889588,
+          "accuracy": 0.8536269430051814
+        }
+      },
+      "expected_vs_experimental": {
+        "source": "output",
+        "confusion_matrix": {
+          "true_positive": 782,
+          "false_positive": 0,
+          "true_negative": 0,
+          "false_negative": 11
+        },
+        "metrics": {
+          "precision": 1.0,
+          "recall": 0.9861286254728878,
+          "f1_score": 0.993015873015873,
+          "accuracy": 0.9861286254728878
+        }
+      }
+    }
+  }
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PolicyAI Experiment Results</title>
+<style>
+/* ── reset & base ───────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #f5f6f8;
+  color: #1d1d1f;
+  line-height: 1.5;
+  padding: 2rem;
+}
+
+/* ── layout ─────────────────────────────────────────────── */
+.container   { max-width: 860px; margin: 0 auto; }
+h1           { font-size: 1.4rem; font-weight: 600; margin-bottom: 1.2rem; }
+h2           { font-size: 1.1rem; font-weight: 600; margin-bottom: .6rem; color: #444; }
+.subhead     { font-size: .85rem; color: #666; margin-bottom: 1.6rem; }
+
+/* ── model picker ───────────────────────────────────────── */
+.picker {
+  display: flex; flex-wrap: wrap; gap: .5rem;
+  margin-bottom: 1.8rem;
+}
+.picker button {
+  padding: .45rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #fff;
+  font-size: .85rem;
+  cursor: pointer;
+  transition: all .15s;
+}
+.picker button:hover           { border-color: #888; }
+.picker button.active          { background: #1d1d1f; color: #fff; border-color: #1d1d1f; }
+
+/* ── cards ──────────────────────────────────────────────── */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+.card {
+  background: #fff;
+  border-radius: 10px;
+  padding: 1.2rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,.08);
+}
+.card .label  { font-size: .75rem; text-transform: uppercase; letter-spacing: .04em; color: #888; }
+.card .value  { font-size: 1.6rem; font-weight: 700; margin-top: .15rem; }
+.card .value.good  { color: #1a7f37; }
+.card .value.warn  { color: #b35900; }
+.card .value.bad   { color: #cf222e; }
+
+/* ── section ────────────────────────────────────────────── */
+.section      { margin-bottom: 2rem; }
+
+/* ── table ──────────────────────────────────────────────── */
+table         { width: 100%; border-collapse: collapse; background: #fff;
+                border-radius: 10px; overflow: hidden;
+                box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+th, td        { text-align: left; padding: .6rem 1rem; font-size: .85rem; }
+th            { background: #fafafa; font-weight: 600; color: #555; border-bottom: 1px solid #eee; }
+td            { border-bottom: 1px solid #f0f0f0; }
+tr:last-child td { border-bottom: none; }
+
+/* ── bar chart ──────────────────────────────────────────── */
+.bar-group        { margin-bottom: .6rem; }
+.bar-label        { font-size: .8rem; color: #555; margin-bottom: .2rem; }
+.bar-track        { height: 22px; background: #eee; border-radius: 4px; position: relative; overflow: hidden; }
+.bar-fill         { height: 100%; border-radius: 4px; transition: width .4s ease; }
+.bar-fill.blue    { background: #3b82f6; }
+.bar-fill.green   { background: #22c55e; }
+.bar-value        { position: absolute; right: 6px; top: 50%; transform: translateY(-50%);
+                    font-size: .7rem; font-weight: 600; color: #333; }
+
+/* ── placeholder ────────────────────────────────────────── */
+#placeholder {
+  text-align: center; padding: 4rem 1rem; color: #999;
+  font-size: .95rem;
+}
+
+/* ── hidden ─────────────────────────────────────────────── */
+.hidden { display: none; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>PolicyAI — Experiment Results</h1>
+  <p class="subhead">Select a model to view its benchmark data.</p>
+
+  <div class="picker" id="picker"></div>
+
+  <div id="placeholder">← Pick a model to get started</div>
+  <div id="dashboard" class="hidden">
+
+    <!-- top-level numbers -->
+    <div class="section">
+      <h2>Overview</h2>
+      <div class="cards" id="overview-cards"></div>
+    </div>
+
+    <!-- policyai vs baseline comparison bars -->
+    <div class="section">
+      <h2>Accuracy — Baseline vs PolicyAI</h2>
+      <div id="accuracy-bars"></div>
+    </div>
+
+    <!-- confusion matrices side-by-side -->
+    <div class="section">
+      <h2>Confusion Matrices</h2>
+      <div class="cards" style="grid-template-columns: 1fr 1fr;">
+        <div class="card">
+          <div class="label" style="margin-bottom:.5rem">Baseline (control)</div>
+          <table id="cm-baseline"></table>
+        </div>
+        <div class="card">
+          <div class="label" style="margin-bottom:.5rem">PolicyAI (experimental)</div>
+          <table id="cm-experimental"></table>
+        </div>
+      </div>
+    </div>
+
+    <!-- detailed metrics table -->
+    <div class="section">
+      <h2>Detailed Metrics</h2>
+      <table id="detail-table"></table>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ================================================================
+   CONFIG — add model slugs here; each must have a matching
+   <slug>.json in the same directory (or DATA_DIR).
+   ================================================================ */
+var MODELS = [
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
+    "gpt-oss-120b",
+    "gpt-oss-20b",
+    "kimi-k2p6",
+    "minimax-m2p7",
+    "opus-4-8"
+];
+
+var DATA_DIR = ".";   // relative to index.html
+
+/* ── helpers ───────────────────────────────────────────────────── */
+function $(sel) { return document.querySelector(sel); }
+function pct(n) { return (n * 100).toFixed(1) + "%"; }
+function ms(n)  { return (n / 1000).toFixed(1) + " s"; }
+function fmt(n) { return typeof n === "number" ? (Number.isInteger(n) ? n.toString() : n.toFixed(2)) : n; }
+
+function makeBar(label, val, max, cls) {
+  var w = Math.min(100, (val / max) * 100);
+  return '<div class="bar-group">' +
+    '<div class="bar-label">' + label + '</div>' +
+    '<div class="bar-track"><div class="bar-fill ' + cls + '" style="width:' + w.toFixed(1) + '%"></div>' +
+    '<span class="bar-value">' + pct(val) + '</span></div></div>';
+}
+
+function cmTable(cm) {
+  return '<thead><tr><th></th><th>Pred +</th><th>Pred −</th></tr></thead>' +
+    '<tbody>' +
+    '<tr><td><strong>Actual +</strong></td><td>' + cm.true_positive + '</td><td>' + cm.false_negative + '</td></tr>' +
+    '<tr><td><strong>Actual −</strong></td><td>' + cm.false_positive + '</td><td>' + cm.true_negative + '</td></tr>' +
+    '</tbody>';
+}
+
+/* ── picker ─────────────────────────────────────────────────────── */
+var pickerEl = $("#picker");
+MODELS.forEach(function(slug) {
+  var btn = document.createElement("button");
+  btn.textContent = slug;
+  btn.addEventListener("click", function() { selectModel(slug); });
+  pickerEl.appendChild(btn);
+});
+
+var activeBtn = null;
+function selectModel(slug) {
+  // highlight button
+  if (activeBtn) activeBtn.classList.remove("active");
+  var btns = pickerEl.querySelectorAll("button");
+  for (var i = 0; i < btns.length; i++) {
+    if (btns[i].textContent === slug) { activeBtn = btns[i]; break; }
+  }
+  activeBtn.classList.add("active");
+
+  // fetch
+  fetch(DATA_DIR + "/" + slug + ".json")
+    .then(function(r) { return r.json(); })
+    .then(function(data) { render(data.summary); })
+    .catch(function(err) {
+      $("#placeholder").textContent = "Failed to load " + slug + ".json — " + err;
+      $("#placeholder").classList.remove("hidden");
+      $("#dashboard").classList.add("hidden");
+    });
+}
+
+/* ── render ─────────────────────────────────────────────────────── */
+function render(s) {
+  $("#placeholder").classList.add("hidden");
+  $("#dashboard").classList.remove("hidden");
+
+  var p = s.policyai;
+  var b = s.baseline;
+  var c = s.comparison;
+  var fma = s.field_match_accuracy;
+
+  // overview cards
+  var expM  = fma.expected_vs_experimental.metrics;
+  var ctrlM = fma.expected_vs_control.metrics;
+
+  var cards = [
+    { label: "Reports",          value: s.total_reports },
+    { label: "PolicyAI F1",      value: pct(expM.f1_score),  cls: expM.f1_score > 0.95 ? "good" : expM.f1_score > 0.8 ? "warn" : "bad" },
+    { label: "Baseline F1",      value: pct(ctrlM.f1_score), cls: ctrlM.f1_score > 0.95 ? "good" : ctrlM.f1_score > 0.8 ? "warn" : "bad" },
+    { label: "Avg Fields Δ",     value: "+" + c.fields_matched_improvement.toFixed(2), cls: "good" },
+    { label: "PolicyAI Latency", value: ms(p.avg_duration_ms) },
+    { label: "Baseline Latency", value: ms(b.avg_duration_ms) },
+  ];
+
+  var html = "";
+  cards.forEach(function(c) {
+    html += '<div class="card"><div class="label">' + c.label + '</div>' +
+            '<div class="value' + (c.cls ? " " + c.cls : "") + '">' + c.value + '</div></div>';
+  });
+  $("#overview-cards").innerHTML = html;
+
+  // accuracy bars
+  html = "";
+  html += makeBar("Baseline Precision",  ctrlM.precision, 1, "blue");
+  html += makeBar("PolicyAI Precision",   expM.precision,  1, "green");
+  html += makeBar("Baseline Recall",      ctrlM.recall,    1, "blue");
+  html += makeBar("PolicyAI Recall",       expM.recall,     1, "green");
+  html += makeBar("Baseline F1",          ctrlM.f1_score,  1, "blue");
+  html += makeBar("PolicyAI F1",           expM.f1_score,   1, "green");
+  $("#accuracy-bars").innerHTML = html;
+
+  // confusion matrices
+  $("#cm-baseline").innerHTML     = cmTable(fma.expected_vs_control.confusion_matrix);
+  $("#cm-experimental").innerHTML = cmTable(fma.expected_vs_experimental.confusion_matrix);
+
+  // detail table
+  var rows = [
+    ["", "Baseline", "PolicyAI"],
+    ["Avg Fields Matched",     fmt(b.avg_fields_matched),       fmt(p.avg_fields_matched)],
+    ["Total Matched Values",   b.total_matched_field_values,    p.total_matched_field_values],
+    ["Wrong Values",           b.total_wrong_values,            p.total_wrong_values],
+    ["Missing Fields",         b.total_missing_fields,          p.total_missing_fields],
+    ["Missing Field Values",   b.total_missing_field_values,    p.total_missing_field_values],
+    ["Extra Fields",           b.total_extra_fields,            p.total_extra_fields],
+    ["Extra Field Values",     b.total_extra_field_values,      p.total_extra_field_values],
+    ["Error Rate",             pct(b.error_rate),               pct(p.error_rate)],
+    ["Avg Duration",           ms(b.avg_duration_ms),           ms(p.avg_duration_ms)],
+  ];
+  html = "<thead><tr>";
+  rows[0].forEach(function(h) { html += "<th>" + h + "</th>"; });
+  html += "</tr></thead><tbody>";
+  for (var i = 1; i < rows.length; i++) {
+    html += "<tr>";
+    rows[i].forEach(function(v, j) {
+      html += j === 0 ? "<td><strong>" + v + "</strong></td>" : "<td>" + v + "</td>";
+    });
+    html += "</tr>";
+  }
+  html += "</tbody>";
+  $("#detail-table").innerHTML = html;
+}
+</script>
+</body>
+</html>

--- a/dashboard/kimi-k2p6.json
+++ b/dashboard/kimi-k2p6.json
@@ -1,0 +1,66 @@
+{
+  "summary": {
+    "total_reports": 300,
+    "policyai": {
+      "avg_fields_matched": 2.6066666666666665,
+      "total_matched_field_values": 782,
+      "total_wrong_values": 13,
+      "total_missing_fields": 14,
+      "total_missing_field_values": 14,
+      "total_extra_fields": 50,
+      "total_extra_field_values": 50,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.0,
+      "avg_duration_ms": 5549.7266666666665
+    },
+    "baseline": {
+      "avg_fields_matched": 1.7966666666666666,
+      "total_matched_field_values": 539,
+      "total_wrong_values": 2,
+      "total_missing_fields": 257,
+      "total_missing_field_values": 257,
+      "total_extra_fields": 8,
+      "total_extra_field_values": 8,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.0,
+      "avg_duration_ms": 1684.6166666666666
+    },
+    "comparison": {
+      "fields_matched_improvement": 0.8099999999999998,
+      "speed_ratio": 0.3035494841187374,
+      "error_rate_difference": 0.0
+    },
+    "field_match_accuracy": {
+      "expected_vs_control": {
+        "source": "baseline",
+        "confusion_matrix": {
+          "true_positive": 539,
+          "false_positive": 8,
+          "true_negative": 0,
+          "false_negative": 257
+        },
+        "metrics": {
+          "precision": 0.9853747714808044,
+          "recall": 0.6771356783919598,
+          "f1_score": 0.8026805658972451,
+          "accuracy": 0.6703980099502488
+        }
+      },
+      "expected_vs_experimental": {
+        "source": "output",
+        "confusion_matrix": {
+          "true_positive": 782,
+          "false_positive": 50,
+          "true_negative": 0,
+          "false_negative": 14
+        },
+        "metrics": {
+          "precision": 0.9399038461538461,
+          "recall": 0.9824120603015075,
+          "f1_score": 0.9606879606879606,
+          "accuracy": 0.9243498817966903
+        }
+      }
+    }
+  }
+}

--- a/dashboard/minimax-m2p7.json
+++ b/dashboard/minimax-m2p7.json
@@ -1,0 +1,66 @@
+{
+  "summary": {
+    "total_reports": 300,
+    "policyai": {
+      "avg_fields_matched": 2.0566666666666666,
+      "total_matched_field_values": 617,
+      "total_wrong_values": 7,
+      "total_missing_fields": 177,
+      "total_missing_field_values": 177,
+      "total_extra_fields": 35,
+      "total_extra_field_values": 35,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.20666666666666667,
+      "avg_duration_ms": 2554.693333333333
+    },
+    "baseline": {
+      "avg_fields_matched": 1.18,
+      "total_matched_field_values": 354,
+      "total_wrong_values": 2,
+      "total_missing_fields": 231,
+      "total_missing_field_values": 231,
+      "total_extra_fields": 2,
+      "total_extra_field_values": 2,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.25333333333333335,
+      "avg_duration_ms": 2035.5833333333333
+    },
+    "comparison": {
+      "fields_matched_improvement": 0.8766666666666667,
+      "speed_ratio": 0.7968014425736684,
+      "error_rate_difference": -0.04666666666666669
+    },
+    "field_match_accuracy": {
+      "expected_vs_control": {
+        "source": "baseline",
+        "confusion_matrix": {
+          "true_positive": 354,
+          "false_positive": 2,
+          "true_negative": 0,
+          "false_negative": 231
+        },
+        "metrics": {
+          "precision": 0.9943820224719101,
+          "recall": 0.6051282051282051,
+          "f1_score": 0.7523910733262487,
+          "accuracy": 0.6030664395229983
+        }
+      },
+      "expected_vs_experimental": {
+        "source": "output",
+        "confusion_matrix": {
+          "true_positive": 617,
+          "false_positive": 35,
+          "true_negative": 0,
+          "false_negative": 177
+        },
+        "metrics": {
+          "precision": 0.946319018404908,
+          "recall": 0.7770780856423174,
+          "f1_score": 0.8533886583679114,
+          "accuracy": 0.744270205066345
+        }
+      }
+    }
+  }
+}

--- a/dashboard/opus-4-8.json
+++ b/dashboard/opus-4-8.json
@@ -1,0 +1,66 @@
+{
+  "summary": {
+    "total_reports": 300,
+    "policyai": {
+      "avg_fields_matched": 2.6233333333333335,
+      "total_matched_field_values": 787,
+      "total_wrong_values": 5,
+      "total_missing_fields": 7,
+      "total_missing_field_values": 7,
+      "total_extra_fields": 23,
+      "total_extra_field_values": 23,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.0033333333333333335,
+      "avg_duration_ms": 6577.483333333334
+    },
+    "baseline": {
+      "avg_fields_matched": 1.34,
+      "total_matched_field_values": 402,
+      "total_wrong_values": 2,
+      "total_missing_fields": 383,
+      "total_missing_field_values": 383,
+      "total_extra_fields": 18,
+      "total_extra_field_values": 18,
+      "total_not_expected_not_output_field_values": 0,
+      "error_rate": 0.01,
+      "avg_duration_ms": 2111.29
+    },
+    "comparison": {
+      "fields_matched_improvement": 1.2833333333333334,
+      "speed_ratio": 0.32098751042065227,
+      "error_rate_difference": -0.006666666666666666
+    },
+    "field_match_accuracy": {
+      "expected_vs_control": {
+        "source": "baseline",
+        "confusion_matrix": {
+          "true_positive": 402,
+          "false_positive": 18,
+          "true_negative": 0,
+          "false_negative": 383
+        },
+        "metrics": {
+          "precision": 0.9571428571428572,
+          "recall": 0.5121019108280255,
+          "f1_score": 0.6672199170124481,
+          "accuracy": 0.5006226650062267
+        }
+      },
+      "expected_vs_experimental": {
+        "source": "output",
+        "confusion_matrix": {
+          "true_positive": 787,
+          "false_positive": 23,
+          "true_negative": 0,
+          "false_negative": 7
+        },
+        "metrics": {
+          "precision": 0.971604938271605,
+          "recall": 0.9911838790931989,
+          "f1_score": 0.9812967581047382,
+          "accuracy": 0.9632802937576499
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Single-page app for visualizing PolicyAI benchmark data per model.
No frameworks or build step—just one index.html that fetches
<slug>.json files from the same directory.

The dashboard displays:
- Overview cards (F1 scores, field-match delta, latency)
- Side-by-side accuracy bars (precision/recall/F1)
- Confusion matrices for baseline vs PolicyAI
- Detailed metrics comparison table

A static MODELS array in the script drives the model picker;
add a slug and drop the corresponding JSON to extend it.

Includes experiment results for seven models:
deepseek-v4-flash, deepseek-v4-pro, gpt-oss-120b, gpt-oss-20b,
kimi-k2p6, minimax-m2p7, and opus-4-8.

Co-authored-by: AI
